### PR TITLE
Using itkGetConstObjectMacro, fixing errors of the style:

### DIFF
--- a/include/itkPhaseCorrelationImageRegistrationMethod.h
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.h
@@ -176,13 +176,13 @@ public:
 
   /** Set/Get the Operator. */
   itkSetObjectMacro( Operator, OperatorType );
-  itkGetObjectMacro( Operator, OperatorType );
+  itkGetConstObjectMacro( Operator, OperatorType );
 
   /** Set/Get the Optimizer. */
   virtual void SetOptimizer (RealOptimizerType *);
   virtual void SetOptimizer (ComplexOptimizerType *);
-  itkGetObjectMacro( RealOptimizer,  RealOptimizerType );
-  itkGetObjectMacro( ComplexOptimizer,  ComplexOptimizerType );
+  itkGetConstObjectMacro( RealOptimizer,  RealOptimizerType );
+  itkGetConstObjectMacro( ComplexOptimizer,  ComplexOptimizerType );
 
   /** Get the correlation surface.
    *


### PR DESCRIPTION
...\itkmontage\include\itkphasecorrelationimageregistrationmethod.h(179): error C3861: 'purposeful_error': identifier not found

These errors appear if ITK_FUTURE_LEGACY_REMOVE is turned ON.