### PR TITLE
BUG: fix huge errors in Tiles test

### DIFF
--- a/include/itkPhaseCorrelationImageRegistrationMethod.h
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.h
@@ -72,7 +72,8 @@ namespace itk
  *  itk::HalfHermitianToRealInverseFFTImageFilter::New() factory.
  *
  *  Step 4. is performed with the run-time supplied PhaseCorrelationOptimizer. It has
- *  to determine the shift from the real or complex correlation surface.
+ *  to determine the shift from the real or complex correlation surface
+ *  and fixed and moving image's origins.
  *
  *
  *  First, plug in the operator, optimizer and the input images. The method

--- a/include/itkPhaseCorrelationImageRegistrationMethod.hxx
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.hxx
@@ -146,10 +146,14 @@ PhaseCorrelationImageRegistrationMethod<TFixedImage,TMovingImage>
     {
     m_IFFT->SetInput( m_Operator->GetOutput() );
     m_RealOptimizer->SetInput( m_IFFT->GetOutput() );
+    m_RealOptimizer->SetFixedImage( m_FixedImage );
+    m_RealOptimizer->SetMovingImage( m_MovingImage );
     }
   else
     {
     m_ComplexOptimizer->SetInput( m_Operator->GetOutput() );
+    m_ComplexOptimizer->SetFixedImage( m_FixedImage );
+    m_ComplexOptimizer->SetMovingImage( m_MovingImage );
     }
 }
 
@@ -265,15 +269,10 @@ PhaseCorrelationImageRegistrationMethod<TFixedImage,TMovingImage>
     }
   itkDebugMacro( "optimization finished" );
 
-  //
-  // now offset is a real-coordinate shift between the two images
-  // but with origin offset not included
   m_TransformParameters = ParametersType( ImageDimension );
-  typename FixedImageType::PointType fixedOrigin = m_FixedImage->GetOrigin();
-  typename MovingImageType::PointType movingOrigin = m_MovingImage->GetOrigin();
   for( unsigned int i = 0; i < ImageDimension; ++i )
     {
-    m_TransformParameters[i] = offset[i] + ( movingOrigin[i] - fixedOrigin[i] );
+    m_TransformParameters[i] = offset[i];
     }
 
   // set the output transform

--- a/include/itkPhaseCorrelationOptimizer.h
+++ b/include/itkPhaseCorrelationOptimizer.h
@@ -82,6 +82,12 @@ public:
   /** Sets the input image to the optimizer. */
   void SetInput( const ImageType * image );
 
+  /** Sets the fixed image to the optimizer. */
+  void SetFixedImage(const ImageBase<ImageType::ImageDimension> * image);
+
+  /** Sets the fixed image to the optimizer. */
+  void SetMovingImage(const ImageBase<ImageType::ImageDimension> * image);
+
   /** Returns the offset resulting from the registration process  */
   const OffsetOutputType * GetOutput() const;
 

--- a/include/itkPhaseCorrelationOptimizer.hxx
+++ b/include/itkPhaseCorrelationOptimizer.hxx
@@ -28,7 +28,7 @@ template < typename TImage >
 PhaseCorrelationOptimizer<TImage>
 ::PhaseCorrelationOptimizer()
 {
-  this->SetNumberOfRequiredInputs( 1 );
+  this->SetNumberOfRequiredInputs( 3 );
   this->SetNumberOfRequiredOutputs( 1 );  // for the parameters
 
   m_Offset.Fill( 0 );
@@ -94,6 +94,36 @@ PhaseCorrelationOptimizer<TImage>
   if ( this->GetInput(0) != image )
     {
     this->ProcessObject::SetNthInput(0, const_cast< ImageType * >( image ) );
+
+    this->Modified();
+    }
+}
+
+
+template < typename TImage >
+void
+PhaseCorrelationOptimizer<TImage>
+::SetFixedImage( const ImageBase<ImageType::ImageDimension> * image )
+{
+  itkDebugMacro("setting fixed image to " << image );
+  if ( this->GetInput(1) != image )
+    {
+    this->ProcessObject::SetNthInput(1, const_cast< ImageBase<ImageType::ImageDimension> * >( image ) );
+
+    this->Modified();
+    }
+}
+
+
+template < typename TImage >
+void
+PhaseCorrelationOptimizer<TImage>
+::SetMovingImage( const ImageBase<ImageType::ImageDimension> * image )
+{
+  itkDebugMacro("setting moving image to " << image );
+  if ( this->GetInput(2) != image )
+    {
+    this->ProcessObject::SetNthInput(2, const_cast< ImageBase<ImageType::ImageDimension> * >( image ) );
 
     this->Modified();
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -107,8 +107,10 @@ itk_add_test(NAME itkPhaseCorrelationImageRegistrationMethodTestFiles
     DATA{Input/OMC/FlatField/14/100.tif}
     DATA{Input/OMC/FlatField/14/101.tif}
     ${TESTING_OUTPUT_PATH}/itkPhaseCorrelationImageRegistrationMethodTestFiles.nrrd
-    168
-    -5
+    1136.0
+    0.0
+    12.0651
+    4.6711893
   )
 
 itk_add_test(NAME itkPhaseCorrelationImageRegistrationMethodTestTiles


### PR DESCRIPTION
PhaseCorrelationImageRegistrationMethod has a symmetry around the image middle.
So pass fixed and moving images to PhaseCorrelationOptimizer so it can choose
the proper quadrant which minimizes the overall translation.

Also update *Files test to take advantage of modifications, and update its ground truth. Now it is within one pixel.

Closes #20.