### PR TITLE
BUG: Remove compilation error "no viable overloaded '='" with Python …

### DIFF
--- a/include/itkPhaseCorrelationImageRegistrationMethod.hxx
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.hxx
@@ -532,7 +532,7 @@ PhaseCorrelationImageRegistrationMethod<TFixedImage, TMovingImage>
   itkDebugMacro("setting fixedImageFFT Image to " << fixedImageFFT );
   if ( this->m_FixedImageFFT.GetPointer() != fixedImageFFT )
     {
-    this->m_FixedImageFFT = fixedImageFFT;
+    this->m_FixedImageFFT = const_cast< ComplexImageType * >(fixedImageFFT);
     this->Modified();
     }
 }
@@ -546,7 +546,7 @@ PhaseCorrelationImageRegistrationMethod<TFixedImage, TMovingImage>
   itkDebugMacro("setting movingImageFFT Image to " << movingImageFFT );
   if ( this->m_MovingImageFFT.GetPointer() != movingImageFFT )
     {
-    this->m_MovingImageFFT = movingImageFFT;
+    this->m_MovingImageFFT = const_cast< ComplexImageType * >(movingImageFFT);
     this->Modified();
     }
 }


### PR DESCRIPTION
…wrapping

ITKMontage/include/itkPhaseCorrelationImageRegistrationMethod.hxx:535:27:\
error: no viable overloaded '='
    this->m_FixedImageFFT = fixedImageFFT;
    ~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~
ITKMontage-build/Wrapping/Modules/Montage/\
itkPhaseCorrelationImageRegistrationMethodPython.cpp:6197:15: \
note: in instantiation of member function
      'itk::PhaseCorrelationImageRegistrationMethod<itk::Image<float, 2>,\
 itk::Image<float, 2> >::SetFixedImageFFT' requested here
      (arg1)->SetFixedImageFFT((itkImageCD2 const *)arg2);