### PR TITLE
ENH: register to adjacent tiles along all dimensions

### DIFF
--- a/include/itkTileMontage.h
+++ b/include/itkTileMontage.h
@@ -176,6 +176,9 @@ protected:
   /** Register a pair of images with given indices. Handles FFTcaching. */
   TransformPointer RegisterPair(TileIndexType fixed, TileIndexType moving);
 
+  /** Removes from memory tile with index smaller by 1 along all dimensions. */
+  void ReleaseMemory(TileIndexType finishedTile);
+
   /** Montage this dimension, and all lower dimensions. */
   void MontageDimension(int d, TileIndexType initialTile);
 

--- a/include/itkTileMontage.h
+++ b/include/itkTileMontage.h
@@ -130,14 +130,14 @@ public:
    * before the call to Update(). */
   void SetInputTile(TileIndexType position, ImageType* image)
   {
-    SizeValueType linInd = this->nDIndexToLinearIndex(position);
-    this->SetNthInput(linInd, image);
-    m_FFTCache[linInd] = nullptr;
+    SizeValueType linearIndex = this->nDIndexToLinearIndex(position);
+    this->SetNthInput(linearIndex, image);
+    m_FFTCache[linearIndex] = nullptr;
   }
   void SetInputTile(TileIndexType position, const std::string& imageFilename)
   {
-    SizeValueType linInd = this->nDIndexToLinearIndex(position);
-    m_Filenames[linInd] = imageFilename;
+    SizeValueType linearIndex = this->nDIndexToLinearIndex(position);
+    m_Filenames[linearIndex] = imageFilename;
     this->SetInputTile(position, m_Dummy);
   }
 
@@ -177,10 +177,18 @@ protected:
   TransformPointer RegisterPair(TileIndexType fixed, TileIndexType moving);
 
   /** Montage this dimension, and all lower dimensions. */
-  void MontageDimension(int d, TransformPointer tInitial, TileIndexType initialTile);
+  void MontageDimension(int d, TileIndexType initialTile);
 
   /** Accesses output, sets a transform to it, and updates progress. */
   void WriteOutTransform(TileIndexType index, TransformPointer transform);
+
+  /** Read out own output at the specified index. */
+  TransformConstPointer GetTransform(TileIndexType index)
+  {
+    const SizeValueType linearIndex = this->nDIndexToLinearIndex(index);
+    auto dOut = this->GetOutput(linearIndex);
+    return static_cast<TransformOutputType *>(dOut)->Get();
+  }
 
   /** Updates mosaic bounds. The transform applies to input.
    *  input0 is tile in the top-left corner. */

--- a/include/itkTileMontage.h
+++ b/include/itkTileMontage.h
@@ -176,7 +176,7 @@ protected:
   /** Register a pair of images with given indices. Handles FFTcaching. */
   TransformPointer RegisterPair(TileIndexType fixed, TileIndexType moving);
 
-  /** Removes from memory tile with index smaller by 1 along all dimensions. */
+  /** If possible, removes from memory tile with index smaller by 1 along all dimensions. */
   void ReleaseMemory(TileIndexType finishedTile);
 
   /** Montage this dimension, and all lower dimensions. */

--- a/include/itkTileMontage.hxx
+++ b/include/itkTileMontage.hxx
@@ -238,29 +238,29 @@ void
 TileMontage<TImageType, TCoordinate>
 ::MontageDimension(int d, TileIndexType initialTile)
 {
-  TileIndexType ind = initialTile;
+  TileIndexType currentIndex = initialTile;
   if (d < 0)
     {
     return; //nothing to do, terminate recursion
     }
   else // d>=0
     {
-    ind[d] = 0; //montage first index in lower dimension
-    MontageDimension(d - 1, ind);
+    currentIndex[d] = 0; //montage first index in lower dimension
+    MontageDimension(d - 1, currentIndex);
 
     for (unsigned i = 1; i < m_MontageSize[d]; i++)
       {
       //register i-th tile to adjacent tiles along all dimension (lower index only)
-      ind[d] = i;
+      currentIndex[d] = i;
       std::vector<TransformPointer> transforms;
       for (unsigned regDim=0; regDim<ImageDimension; regDim++)
         {
-        if (ind[regDim] > 0) //we are not at the edge along this dimension
+        if (currentIndex[regDim] > 0) //we are not at the edge along this dimension
           {
-          TileIndexType indF = ind;
-          indF[regDim] = ind[regDim] - 1;
-          TransformPointer t = this->RegisterPair(indF, ind);
-          TransformConstPointer oldT = this->GetTransform(indF);
+          TileIndexType referenceIndex = currentIndex;
+          referenceIndex[regDim] = currentIndex[regDim] - 1;
+          TransformPointer t = this->RegisterPair(referenceIndex, currentIndex);
+          TransformConstPointer oldT = this->GetTransform(referenceIndex);
           t->Compose(oldT, true);
           transforms.push_back(t);
           }
@@ -273,17 +273,17 @@ TileMontage<TImageType, TCoordinate>
         t->SetOffset(t->GetOffset() + transforms[ti]->GetOffset() / transforms.size());
         }
 
-      this->WriteOutTransform(ind, t);
+      this->WriteOutTransform(currentIndex, t);
 
       //montage this index in lower dimension
-      MontageDimension(d - 1, ind);
+      MontageDimension(d - 1, currentIndex);
 
-      this->ReleaseMemory(ind); //kick old tile out of cache
+      this->ReleaseMemory(currentIndex); //kick old tile out of cache
       }
 
     //kick "rightmost" tile in previous row out of cache
-    ind[d] = m_MontageSize[d];
-    this->ReleaseMemory(ind);
+    currentIndex[d] = m_MontageSize[d];
+    this->ReleaseMemory(currentIndex);
     }
 }
 

--- a/test/itkMontageTestHelper.hxx
+++ b/test/itkMontageTestHelper.hxx
@@ -126,7 +126,7 @@ int montageTest(const PositionTableType& stageCoords, const PositionTableType& a
       //so its modification does not cause a pipeline update automatically
 
       std::cout << "    PeakMethod " << peakMethod << std::endl;
-      itk::SimpleFilterWatcher fw(montage);
+      itk::SimpleFilterWatcher fw(montage, "montage");
       montage->Update();
 
       std::cout << std::fixed;
@@ -170,7 +170,7 @@ int montageTest(const PositionTableType& stageCoords, const PositionTableType& a
       // write generated mosaic
       using Resampler = itk::TileMergeImageFilter<ImageType>;
       typename Resampler::Pointer resampleF = Resampler::New();
-      itk::SimpleFilterWatcher fw2(resampleF);
+      itk::SimpleFilterWatcher fw2(resampleF, "resampler");
       if (setMontageDirectly)
         {
         resampleF->SetMontage(montage);


### PR DESCRIPTION
Also releases FFT cache and tile memory at earliest possible time.

Closes #47.