### PR TITLE
Force padding always, it improves registration reliability

### DIFF
--- a/include/itkMaxPhaseCorrelationOptimizer.hxx
+++ b/include/itkMaxPhaseCorrelationOptimizer.hxx
@@ -137,15 +137,18 @@ MaxPhaseCorrelationOptimizer<TRegistrationMethod>
       } //for ImageDimension
     } //if Interpolation != None
 
-  const typename ImageType::SizeType size = input->GetLargestPossibleRegion().GetSize();
+  const typename ImageType::RegionType lpr = input->GetLargestPossibleRegion();
+  const typename ImageType::IndexType oIndex = lpr.GetIndex();
+  const typename ImageType::SizeType size = lpr.GetSize();
   const typename ImageType::SpacingType spacing = input->GetSpacing();
   const typename ImageType::PointType fixedOrigin = fixed->GetOrigin();
   const typename ImageType::PointType movingOrigin = moving->GetOrigin();
 
   for( unsigned int i = 0; i < ImageDimension; ++i )
     {
-    OffsetScalarType directOffset = (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * maxIndex[i];
-    OffsetScalarType mirrorOffset = (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - IndexValueType(size[i]));
+    IndexValueType adjustedSize = IndexValueType(size[i] + oIndex[i]);
+    OffsetScalarType directOffset = (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - oIndex[i]);
+    OffsetScalarType mirrorOffset = (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - adjustedSize);
     if (std::abs(directOffset) <= std::abs(mirrorOffset))
       {
       offset[i] = directOffset;

--- a/include/itkPhaseCorrelationImageRegistrationMethod.h
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.h
@@ -223,6 +223,12 @@ public:
   itkSetMacro(PadToSize, SizeType);
   itkGetConstMacro(PadToSize, SizeType);
 
+  /** Set/Get obligatory padding.
+   * If set, padding of this many pixels is added on both beginning and end
+   * sides of each dimension of the image. */
+  itkSetMacro(ObligatoryPadding, SizeType);
+  itkGetConstMacro(ObligatoryPadding, SizeType);
+
   /** \class PaddingMethod
    *  \brief Different methods of padding the images to satisfy FFT size requirements.
    *  \ingroup Montage */
@@ -329,6 +335,7 @@ private:
 
   ParametersType m_TransformParameters;
   SizeType       m_PadToSize;
+  SizeType       m_ObligatoryPadding;
   PaddingMethod  m_PaddingMethod;
 
   typename FixedPadderImageFilter::Pointer    m_FixedPadder;

--- a/include/itkPhaseCorrelationImageRegistrationMethod.hxx
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.hxx
@@ -87,8 +87,8 @@ PhaseCorrelationImageRegistrationMethod<TFixedImage,TMovingImage>
   m_MovingMirrorWEDPadder->SetDecayBase( 0.75 );
 
   m_PadToSize.Fill( 0 );
-  m_PaddingMethod = PaddingMethod::MirrorWithExponentialDecay; //make sure the next call does modifications
-  SetPaddingMethod(PaddingMethod::Zero); //this initializes a few things
+  m_PaddingMethod = PaddingMethod::Zero; //make sure the next call does modifications
+  SetPaddingMethod(PaddingMethod::MirrorWithExponentialDecay); //this initializes a few things
 
   m_TransformParameters = ParametersType(ImageDimension);
   m_TransformParameters.Fill( 0.0f );

--- a/include/itkTileMergeImageFilter.hxx
+++ b/include/itkTileMergeImageFilter.hxx
@@ -254,7 +254,8 @@ TileMergeImageFilter<TImageType, TPixelAccumulateType, TInterpolator>
   SizeValueType linearIndex = this->nDIndexToLinearIndex(nDIndex);
   const auto cInput = static_cast<ImageType *>(this->GetInput(linearIndex));
   ImagePointer input = const_cast<ImageType *>(cInput);
-  if (input.GetPointer() == reinterpret_cast<ImageType *>(this->m_Dummy.GetPointer()))
+  if (input.GetPointer() == reinterpret_cast<ImageType *>(this->m_Dummy.GetPointer())
+      || wantedRegion.GetNumberOfPixels() > 0)
     {
     ImagePointer outputImage = this->GetOutput();
     RegionType reqR = outputImage->GetRequestedRegion();
@@ -458,8 +459,11 @@ TileMergeImageFilter<TImageType, TPixelAccumulateType, TInterpolator>
   RegionType reg0;
   for (SizeValueType i = 0; i < this->m_LinearMontageSize; i++)
     {
-    m_Tiles[i]->SetBufferedRegion(reg0);
-    m_Tiles[i]->Allocate(false);
+    if (m_Tiles[i])
+      {
+      m_Tiles[i]->SetBufferedRegion(reg0);
+      m_Tiles[i]->Allocate(false);
+      }
     }
 }
 

--- a/include/itkTileMontage.h
+++ b/include/itkTileMontage.h
@@ -116,8 +116,30 @@ public:
   itkSetMacro(ForcedSpacing, SpacingType);
   itkGetConstMacro(ForcedSpacing, SpacingType);
 
+  /** Set/Get obligatory padding.
+   * If set, padding of this many pixels is added on both beginning and end
+   * sides of each dimension of the image. */
+  virtual void SetObligatoryPadding(const SizeType pad)
+  {
+    if (this->m_ObligatoryPadding != pad)
+      {
+      this->m_ObligatoryPadding = pad;
+      m_PCM->SetObligatoryPadding(pad);
+      this->Modified();
+      }
+  }
+  itkGetConstMacro(ObligatoryPadding, SizeType);
+
   /** Set/Get the PhaseCorrelationImageRegistrationMethod. */
-  itkSetObjectMacro(PCM, PCMType);
+  virtual void SetPCM(PCMType* pcm)
+  {
+    if (this->m_PCM != pcm)
+      {
+      this->m_PCM = pcm;
+      m_PCM->SetObligatoryPadding(m_ObligatoryPadding);
+      this->Modified();
+      }
+  }
   itkGetModifiableObjectMacro(PCM, PCMType);
 
   /** Set/Get the PhaseCorrelationImageRegistrationMethod. */
@@ -170,7 +192,7 @@ protected:
   using ReaderType = itk::ImageFileReader< ImageType >;
 
   /** Just get image pointer if the image is present, otherwise read it from file. */
-  ImageType* GetImage(TileIndexType nDIndex);
+  ImageType* GetImage(TileIndexType nDIndex, bool metadatOnly);
 
   DataObjectPointerArraySizeType nDIndexToLinearIndex(TileIndexType nDIndex) const;
   TileIndexType LinearIndexTonDIndex(DataObjectPointerArraySizeType linearIndex) const;
@@ -214,6 +236,7 @@ private:
     SizeValueType m_FinishedTiles;
     PointType     m_OriginAdjustment;
     SpacingType   m_ForcedSpacing;
+    SizeType      m_ObligatoryPadding;
 
     std::vector<std::string>     m_Filenames;
     std::vector<FFTConstPointer> m_FFTCache;

--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -19,6 +19,7 @@ itk_module(Montage
     ITKIOImageBase
   TEST_DEPENDS
     ITKIOTransformInsightLegacy
+    # ITKIOHDF5 # hdf5 is another format which supports streaming
     ITKTestKernel
   DESCRIPTION
     "${DOCUMENTATION}"

--- a/test/itkMockMontageHelper.hxx
+++ b/test/itkMockMontageHelper.hxx
@@ -61,6 +61,9 @@ double calculateError(const PositionTableType& initalCoords, const PositionTable
   typename PhaseCorrelationMethodType::Pointer phaseCorrelationMethod = PhaseCorrelationMethodType::New();
   phaseCorrelationMethod->SetFixedImage(fixedImage);
   phaseCorrelationMethod->SetMovingImage(movingImage);
+  typename PhaseCorrelationMethodType::SizeType pad;
+  pad.Fill(8 * sizeof(PixelType));
+  phaseCorrelationMethod->SetObligatoryPadding(pad);
   //phaseCorrelationMethod->DebugOn();
 
   using PMType = typename PhaseCorrelationMethodType::PaddingMethod;
@@ -96,9 +99,6 @@ double calculateError(const PositionTableType& initalCoords, const PositionTable
     out << '\t' << peakMethod;
     std::cout << "    PeakMethod" << peakMethod << ":";
 
-    typename PhaseCorrelationMethodType::SizeType imageSize = fixedImage->GetLargestPossibleRegion().GetSize();
-    imageSize = phaseCorrelationMethod->RoundUpToFFTSize(imageSize);
-    phaseCorrelationMethod->SetPadToSize(imageSize); //all images are the same size
     phaseCorrelationMethod->Update();
 
     using TransformType = itk::TranslationTransform<double, Dimension>;

--- a/test/itkMontagePCMTestFiles.cxx
+++ b/test/itkMontagePCMTestFiles.cxx
@@ -65,6 +65,9 @@ int PhaseCorrelationRegistrationFiles( int argc, char* argv[] )
   typename PhaseCorrelationMethodType::Pointer phaseCorrelationMethod = PhaseCorrelationMethodType::New();
   phaseCorrelationMethod->SetFixedImage( fixedImage );
   phaseCorrelationMethod->SetMovingImage( movingImage );
+  typename PhaseCorrelationMethodType::SizeType pad;
+  pad.Fill(8 * sizeof(TFixedImagePixel));
+  phaseCorrelationMethod->SetObligatoryPadding(pad);
   phaseCorrelationMethod->DebugOn();
 
   // Operator type

--- a/test/itkMontageTestHelper.hxx
+++ b/test/itkMontageTestHelper.hxx
@@ -62,10 +62,11 @@ void WriteTransform(const TransformType* transform, std::string filename)
 
 //do the registrations and calculate registration errors
 //negative peakMethodToUse means to try them all
+//streamSubdivisions of 1 disables streaming (higher memory useage, less cluttered debug output)
 template<typename PixelType, typename AccumulatePixelType, unsigned xMontageSize, unsigned yMontageSize, typename PositionTableType, typename FilenameTableType>
 int montageTest(const PositionTableType& stageCoords, const PositionTableType& actualCoords,
     const FilenameTableType& filenames, const std::string& outFilename, bool varyPaddingMethods,
-    int peakMethodToUse, bool setMontageDirectly)
+    int peakMethodToUse, bool setMontageDirectly, unsigned streamSubdivisions)
 {
   int result = EXIT_SUCCESS;
   using ScalarPixelType = typename itk::NumericTraits<PixelType>::ValueType;
@@ -208,7 +209,7 @@ int montageTest(const PositionTableType& stageCoords, const PositionTableType& a
       //MetaImage format supports streaming
       w->SetFileName(outFilename + std::to_string(padMethod) + "_" + std::to_string(peakMethod) + ".mha");
       //w->UseCompressionOn();
-      w->SetNumberOfStreamDivisions(3);
+      w->SetNumberOfStreamDivisions(streamSubdivisions);
       w->Update();
       if (peakMethodToUse >= 0) //peak method was specified
         {

--- a/test/itkMontageTestOMC.cxx
+++ b/test/itkMontageTestOMC.cxx
@@ -81,8 +81,10 @@ int itkMontageTestOMC(int argc, char* argv[])
       }
     }
 
-  int r2 = montageTest<unsigned short, double, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[3], true, -1, false);
-  int r1 = mockMontageTest<unsigned short, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[2], true);
+  int r2 = montageTest<unsigned short, double, xMontageSize, yMontageSize>(
+      stageCoords, actualCoords, filenames, argv[3], true, -1, false, 1);
+  int r1 = mockMontageTest<unsigned short, xMontageSize, yMontageSize>(
+      stageCoords, actualCoords, filenames, argv[2], true);
 
   if (r1 == EXIT_FAILURE || r2 == EXIT_FAILURE)
     {

--- a/test/itkMontageTestRGB.cxx
+++ b/test/itkMontageTestRGB.cxx
@@ -69,8 +69,10 @@ int itkMontageTestRGB(int argc, char* argv[])
       }
     }
 
-  int r2 = montageTest<PixelType, itk::RGBPixel<unsigned int>, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[3], true, -1, false);
-  int r1 = mockMontageTest<unsigned char, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[2], false);
+  int r2 = montageTest<PixelType, itk::RGBPixel<unsigned int>, xMontageSize, yMontageSize>(
+      stageCoords, actualCoords, filenames, argv[3], true, -1, false, 1);
+  int r1 = mockMontageTest<unsigned char, xMontageSize, yMontageSize>(
+      stageCoords, actualCoords, filenames, argv[2], false);
 
   if (r1 == EXIT_FAILURE || r2 == EXIT_FAILURE)
     {

--- a/test/itkMontageTestTi7.cxx
+++ b/test/itkMontageTestTi7.cxx
@@ -82,7 +82,7 @@ int itkMontageTestTi7(int argc, char* argv[])
     }
 
   //do not vary padding methods in order to finish sooner
-  int r2 = montageTest<unsigned short, double, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[3], false, 1, false);
+  int r2 = montageTest<unsigned short, double, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[3], false, 1, false, 10);
   int r1 = mockMontageTest<unsigned short, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[2], false);
 
   if (r1 == EXIT_FAILURE || r2 == EXIT_FAILURE)

--- a/test/itkMontageTestTiles.cxx
+++ b/test/itkMontageTestTiles.cxx
@@ -72,8 +72,10 @@ int itkMontageTestTiles(int argc, char* argv[])
     }
 
   //do not vary padding methods, because padding is not required for images in this test 
-  int r2 = montageTest<unsigned short, double, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[3], false, -1, true);
-  int r1 = mockMontageTest<unsigned short, xMontageSize, yMontageSize>(stageCoords, actualCoords, filenames, argv[2], false);
+  int r2 = montageTest<unsigned short, double, xMontageSize, yMontageSize>(
+      stageCoords, actualCoords, filenames, argv[3], false, -1, true, 1);
+  int r1 = mockMontageTest<unsigned short, xMontageSize, yMontageSize>(
+      stageCoords, actualCoords, filenames, argv[2], false);
 
   if (r1 == EXIT_FAILURE || r2 == EXIT_FAILURE)
     {


### PR DESCRIPTION
For NoisyTiles test, the average translation error for padding method 0 goes from 342.953 pixels down to 285.358