### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/test/itkMontagePCMTestFiles.cxx
+++ b/test/itkMontagePCMTestFiles.cxx
@@ -56,7 +56,7 @@ int PhaseCorrelationRegistrationFiles( int argc, char* argv[] )
   typename MovingImageType::PointType origin = movingImage->GetOrigin();
   for (unsigned d = 0; d < VDimension; d++)
     {
-    origin[d] = atof(argv[4 + d]);
+    origin[d] = std::stod(argv[4 + d]);
     }
   movingImage->SetOrigin(origin);
 
@@ -99,7 +99,7 @@ int PhaseCorrelationRegistrationFiles( int argc, char* argv[] )
     ParametersType actualParameters( numberOfParameters );
     for (unsigned int ii = 4 + VDimension; ii < 4 + VDimension + numberOfParameters; ++ii)
       {
-      actualParameters[ii - 4 - VDimension] = atof( argv[ii] );
+      actualParameters[ii - 4 - VDimension] = std::stod( argv[ii] );
       }
 
 

--- a/test/itkMontagePCMTestSynthetic.cxx
+++ b/test/itkMontagePCMTestSynthetic.cxx
@@ -182,7 +182,7 @@ int PhaseCorrelationRegistration( int argc, char* argv[] )
         //movingSpacing[i] = 1.0 / (0.8 + i); //test different spacing (unsupported)
         if (argc > 4 + int(i))
           {
-          movingSpacing[i] = atof(argv[4 + i]);
+          movingSpacing[i] = std::stod(argv[4 + i]);
           }
         movingSize[i] = (unsigned long)(size[i] / movingSpacing[i] + 3 * std::pow(-1, i));
         movingSize[i] = std::max<itk::SizeValueType>(movingSize[i], 7u);


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/