### PR TITLE
WIP: parse TileConfiguration.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,19 @@
 cmake_minimum_required(VERSION 3.10.2)
+
+if(CMAKE_CXX_STANDARD EQUAL "98" )
+   message(FATAL_ERROR "CMAKE_CXX_STANDARD:STRING=98 is not supported in ITK version 5 and greater.")
+endif()
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11) # Supported values are ``11``, ``14``, and ``17``.
+endif()
+if(NOT CMAKE_CXX_STANDARD_REQUIRED)
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
+if(NOT CMAKE_CXX_EXTENSIONS)
+  set(CMAKE_CXX_EXTENSIONS OFF)
+endif()
+
 project(Montage)
 
 #set(Montage_LIBRARIES Montage)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,13 +16,14 @@ endif()
 
 project(Montage)
 
-#set(Montage_LIBRARIES Montage)
+set(Montage_LIBRARIES Montage)
 
 if(NOT ITK_SOURCE_DIR)
   find_package(ITK REQUIRED)
   list(APPEND CMAKE_MODULE_PATH ${ITK_CMAKE_DIR})
   include(ITKModuleExternal)
 else()
+  set(ITK_DIR ${CMAKE_BINARY_DIR})
   itk_module_impl()
 endif()
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,9 +1,18 @@
-cmake_minimum_required(VERSION 3.9.5)
+cmake_minimum_required(VERSION 3.10.2)
 project(ITKMontageExamples)
 
-find_package(ITK REQUIRED
-  COMPONENTS ITKImageIO ITKTransformIO Montage
-  )
+if(NOT ITK_SOURCE_DIR)
+  find_package(ITK REQUIRED COMPONENTS ITKImageIO ITKTransformIO Montage)
+else()
+  # when being built as part of ITK, ITKImageIO and ITKTransformIO
+  # lists of modules are not yet ready, causing a configure error
+  find_package(ITK REQUIRED COMPONENTS
+    Montage
+    ITKTestKernel # includes many I/O modules
+    ITKIOTransformInsightLegacy
+    ITKIOHDF5
+    )
+endif()
 include(${ITK_USE_FILE})
 
 add_executable(PhaseCorrelationImageRegistration

--- a/include/itkParseTileConfiguration.h
+++ b/include/itkParseTileConfiguration.h
@@ -22,8 +22,7 @@
 #include "MontageExport.h"
 
 #include <string>
-#include <fstream>
-#include <sstream>
+#include <vector>
 
 #include "itkPoint.h"
 

--- a/include/itkParseTileConfiguration.h
+++ b/include/itkParseTileConfiguration.h
@@ -1,0 +1,142 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#ifndef itkParseTileConfiguration_h
+#define itkParseTileConfiguration_h
+
+#include <string>
+#include <fstream>
+#include <sstream>
+
+std::string
+getNextNonCommentLine( std::istream& in )
+{
+  std::string temp;
+  while ( std::getline( in, temp ) )
+    {
+    // this is neither an empty line nor a comment
+    if ( !temp.empty() && temp[0] != '#' )
+      {
+      break;
+      }
+    }
+  return temp;
+}
+
+template< unsigned Dimension >
+struct Tile
+{
+  itk::Point< double, Dimension > Position; // x, y... coordinates
+
+  std::string FileName;
+};
+
+template< unsigned Dimension >
+Tile< Dimension >
+parseLine( const std::string line, std::string& timePointID )
+{
+  Tile< Dimension > tile;
+  std::stringstream ss( line );
+  std::string temp;
+
+  std::getline( ss, temp, ';' );
+  tile.FileName = temp;
+  std::getline( ss, temp, ';' );
+  timePointID = temp;
+  std::getline( ss, temp, '(' );
+
+  using PointType = itk::Point< double, Dimension >;
+  PointType p;
+  for (unsigned d = 0; d < Dimension; d++)
+    {
+    ss >> p[d]; //TODO: use DoubleConversion here!
+    ss.ignore();
+    }
+  tile.Position = p;
+
+  return tile;
+}
+
+template< unsigned Dimension >
+std::vector< Tile< Dimension > >
+parseRow( std::string& line, std::istream& in, std::string& timePointID )
+{
+  std::vector< Tile< Dimension > > row;
+
+  Tile< Dimension > tile = parseLine< Dimension >( line, timePointID );
+  row.push_back( tile );
+  line = getNextNonCommentLine( in );
+
+  while (in)
+    {
+    tile = parseLine< Dimension >( line, timePointID );
+    if ( tile.Position[0] < row.back().Position[0] ) // this is start of a new row
+      {
+      return row;
+      }
+    row.push_back( tile );
+    line = getNextNonCommentLine( in );
+    }
+
+  return row;
+}
+
+
+std::vector< std::vector< Tile< 2 > > >
+parseTileConfiguration2D( const std::string pathToFile )
+{
+  constexpr unsigned Dimension = 2;
+  using PointType = itk::Point< double, Dimension >;
+  using TileRow = std::vector< Tile< Dimension > >;
+  using TileLayout = std::vector< TileRow >;
+
+  unsigned xMontageSize = 0;
+  TileLayout tiles;
+  std::string timePointID; // just to make sure all lines specify the same time point
+
+  std::ifstream tileFile( pathToFile );
+  std::string temp = getNextNonCommentLine( tileFile );
+  if (temp.substr(0, 6) == "dim = ")
+    {
+    unsigned dim = std::stoul( temp.substr( 6 ) );
+    if (dim != Dimension)
+      {
+      throw std::runtime_error( "Expected dimension 2, but got " + std::to_string( dim ) + " from string:\n\n" + temp );
+      }
+    temp = getNextNonCommentLine( tileFile ); //get next line
+    }
+
+  // read coordinates from files
+  while ( tileFile )
+    {
+    TileRow tileRow = parseRow< Dimension >( temp, tileFile, timePointID );
+    if (xMontageSize == 0)
+      {
+      xMontageSize = tileRow.size(); // we get size from first row
+      }
+    else // check it is the same size as first row
+      {
+      assert( xMontageSize == tileRow.size() );
+      }
+    tiles.push_back( tileRow );
+    }
+
+  return tiles;
+}
+
+#endif // itkParseTileConfiguration_h

--- a/include/itkParseTileConfiguration.h
+++ b/include/itkParseTileConfiguration.h
@@ -19,25 +19,16 @@
 #ifndef itkParseTileConfiguration_h
 #define itkParseTileConfiguration_h
 
+#include "MontageExport.h"
+
 #include <string>
 #include <fstream>
 #include <sstream>
 
-std::string
-getNextNonCommentLine( std::istream& in )
-{
-  std::string temp;
-  while ( std::getline( in, temp ) )
-    {
-    // this is neither an empty line nor a comment
-    if ( !temp.empty() && temp[0] != '#' )
-      {
-      break;
-      }
-    }
-  return temp;
-}
+#include "itkPoint.h"
 
+namespace itk
+{
 template< unsigned Dimension >
 struct Tile
 {
@@ -46,97 +37,9 @@ struct Tile
   std::string FileName;
 };
 
-template< unsigned Dimension >
-Tile< Dimension >
-parseLine( const std::string line, std::string& timePointID )
-{
-  Tile< Dimension > tile;
-  std::stringstream ss( line );
-  std::string temp;
+Montage_EXPORT std::vector< std::vector< Tile< 2 > > >
+ParseTileConfiguration2D( const std::string pathToFile );
 
-  std::getline( ss, temp, ';' );
-  tile.FileName = temp;
-  std::getline( ss, temp, ';' );
-  timePointID = temp;
-  std::getline( ss, temp, '(' );
-
-  using PointType = itk::Point< double, Dimension >;
-  PointType p;
-  for (unsigned d = 0; d < Dimension; d++)
-    {
-    ss >> p[d]; //TODO: use DoubleConversion here!
-    ss.ignore();
-    }
-  tile.Position = p;
-
-  return tile;
-}
-
-template< unsigned Dimension >
-std::vector< Tile< Dimension > >
-parseRow( std::string& line, std::istream& in, std::string& timePointID )
-{
-  std::vector< Tile< Dimension > > row;
-
-  Tile< Dimension > tile = parseLine< Dimension >( line, timePointID );
-  row.push_back( tile );
-  line = getNextNonCommentLine( in );
-
-  while (in)
-    {
-    tile = parseLine< Dimension >( line, timePointID );
-    if ( tile.Position[0] < row.back().Position[0] ) // this is start of a new row
-      {
-      return row;
-      }
-    row.push_back( tile );
-    line = getNextNonCommentLine( in );
-    }
-
-  return row;
-}
-
-
-std::vector< std::vector< Tile< 2 > > >
-parseTileConfiguration2D( const std::string pathToFile )
-{
-  constexpr unsigned Dimension = 2;
-  using PointType = itk::Point< double, Dimension >;
-  using TileRow = std::vector< Tile< Dimension > >;
-  using TileLayout = std::vector< TileRow >;
-
-  unsigned xMontageSize = 0;
-  TileLayout tiles;
-  std::string timePointID; // just to make sure all lines specify the same time point
-
-  std::ifstream tileFile( pathToFile );
-  std::string temp = getNextNonCommentLine( tileFile );
-  if (temp.substr(0, 6) == "dim = ")
-    {
-    unsigned dim = std::stoul( temp.substr( 6 ) );
-    if (dim != Dimension)
-      {
-      throw std::runtime_error( "Expected dimension 2, but got " + std::to_string( dim ) + " from string:\n\n" + temp );
-      }
-    temp = getNextNonCommentLine( tileFile ); //get next line
-    }
-
-  // read coordinates from files
-  while ( tileFile )
-    {
-    TileRow tileRow = parseRow< Dimension >( temp, tileFile, timePointID );
-    if (xMontageSize == 0)
-      {
-      xMontageSize = tileRow.size(); // we get size from first row
-      }
-    else // check it is the same size as first row
-      {
-      assert( xMontageSize == tileRow.size() );
-      }
-    tiles.push_back( tileRow );
-    }
-
-  return tiles;
-}
+} // namespace itk
 
 #endif // itkParseTileConfiguration_h

--- a/include/itkTileMergeImageFilter.h
+++ b/include/itkTileMergeImageFilter.h
@@ -93,7 +93,7 @@ public:
   using typename Superclass::ImageIndexType;
   using typename Superclass::OffsetType;
   using typename Superclass::PointType;
-  using typename Superclass::RegionType; // using RegionType = typename Superclass::RegionType;
+  using RegionType = typename Superclass::RegionType;
   using typename Superclass::SpacingType;
 
   /**  Type for the transform. */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,4 @@ set(Montage_SRC
   itkParseTileConfiguration.cxx
   )
 
-add_library(Montage ${Montage_SRC})
-# target_link_libraries(Montage ${ITKCommon}) # we do not link-depend on anything
-itk_module_target(Montage)
+itk_module_add_library(Montage ${Montage_SRC})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(Montage_SRC
+  itkParseTileConfiguration.cxx
+  )
+
+add_library(Montage ${Montage_SRC})
+# target_link_libraries(Montage ${ITKCommon}) # we do not link-depend on anything
+itk_module_target(Montage)

--- a/src/itkParseTileConfiguration.cxx
+++ b/src/itkParseTileConfiguration.cxx
@@ -95,7 +95,7 @@ parseRow( std::string& line, std::istream& in, std::string& timePointID )
 
 namespace itk
 {
-Montage_EXPORT std::vector< std::vector< Tile< 2 > > >
+std::vector< std::vector< Tile< 2 > > >
 ParseTileConfiguration2D( const std::string pathToFile )
 {
   constexpr unsigned Dimension = 2;

--- a/src/itkParseTileConfiguration.cxx
+++ b/src/itkParseTileConfiguration.cxx
@@ -1,0 +1,140 @@
+/*=========================================================================
+ *
+ *  Copyright Insight Software Consortium
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0.txt
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *=========================================================================*/
+
+#include "itkParseTileConfiguration.h"
+
+#include <string>
+#include <fstream>
+#include <sstream>
+
+namespace // annonymous namespace
+{
+std::string
+getNextNonCommentLine( std::istream& in )
+{
+  std::string temp;
+  while ( std::getline( in, temp ) )
+    {
+    // this is neither an empty line nor a comment
+    if ( !temp.empty() && temp[0] != '#' )
+      {
+      break;
+      }
+    }
+  return temp;
+}
+
+template< unsigned Dimension >
+itk::Tile< Dimension >
+parseLine( const std::string line, std::string& timePointID )
+{
+  itk::Tile< Dimension > tile;
+  std::stringstream ss( line );
+  std::string temp;
+
+  std::getline( ss, temp, ';' );
+  tile.FileName = temp;
+  std::getline( ss, temp, ';' );
+  timePointID = temp;
+  std::getline( ss, temp, '(' );
+
+  using PointType = itk::Point< double, Dimension >;
+  PointType p;
+  for (unsigned d = 0; d < Dimension; d++)
+    {
+    ss >> p[d]; //TODO: use DoubleConversion here!
+    ss.ignore();
+    }
+  tile.Position = p;
+
+  return tile;
+}
+
+template< unsigned Dimension >
+std::vector< itk::Tile< Dimension > >
+parseRow( std::string& line, std::istream& in, std::string& timePointID )
+{
+  std::vector< itk::Tile< Dimension > > row;
+
+  itk::Tile< Dimension > tile = parseLine< Dimension >( line, timePointID );
+  row.push_back( tile );
+  line = getNextNonCommentLine( in );
+
+  while (in)
+    {
+    tile = parseLine< Dimension >( line, timePointID );
+    if ( tile.Position[0] < row.back().Position[0] ) // this is start of a new row
+      {
+      return row;
+      }
+    row.push_back( tile );
+    line = getNextNonCommentLine( in );
+    }
+
+  return row;
+}
+
+} // annonymous namespace
+
+
+
+namespace itk
+{
+Montage_EXPORT std::vector< std::vector< Tile< 2 > > >
+ParseTileConfiguration2D( const std::string pathToFile )
+{
+  constexpr unsigned Dimension = 2;
+  using PointType = itk::Point< double, Dimension >;
+  using TileRow = std::vector< Tile< Dimension > >;
+  using TileLayout = std::vector< TileRow >;
+
+  unsigned xMontageSize = 0;
+  TileLayout tiles;
+  std::string timePointID; // just to make sure all lines specify the same time point
+
+  std::ifstream tileFile( pathToFile );
+  std::string temp = getNextNonCommentLine( tileFile );
+  if (temp.substr(0, 6) == "dim = ")
+    {
+    unsigned dim = std::stoul( temp.substr( 6 ) );
+    if (dim != Dimension)
+      {
+      throw std::runtime_error( "Expected dimension 2, but got " + std::to_string( dim ) + " from string:\n\n" + temp );
+      }
+    temp = getNextNonCommentLine( tileFile ); //get next line
+    }
+
+  // read coordinates from files
+  while ( tileFile )
+    {
+    TileRow tileRow = parseRow< Dimension >( temp, tileFile, timePointID );
+    if (xMontageSize == 0)
+      {
+      xMontageSize = tileRow.size(); // we get size from first row
+      }
+    else // check it is the same size as first row
+      {
+      assert( xMontageSize == tileRow.size() );
+      }
+    tiles.push_back( tileRow );
+    }
+
+  return tiles;
+}
+
+} // namespace itk

--- a/src/itkParseTileConfiguration.cxx
+++ b/src/itkParseTileConfiguration.cxx
@@ -18,7 +18,7 @@
 
 #include "itkParseTileConfiguration.h"
 
-#include <string>
+#include <cassert>
 #include <fstream>
 #include <sstream>
 

--- a/test/itkMontageTestOMC.cxx
+++ b/test/itkMontageTestOMC.cxx
@@ -18,6 +18,7 @@
 
 #include "itkMockMontageHelper.hxx"
 #include "itkMontageTestHelper.hxx"
+#include "itkParseTileConfiguration.h"
 
 int itkMontageTestOMC(int argc, char* argv[])
 {
@@ -39,6 +40,10 @@ int itkMontageTestOMC(int argc, char* argv[])
 
   PositionTableType stageCoords, actualCoords;
   FilenameTableType filenames;
+
+  std::vector< std::vector< Tile< 2 > > > tc =
+    parseTileConfiguration2D( std::string( argv[1] ) + "/TileConfiguration.txt" );
+  tc = parseTileConfiguration2D( std::string( argv[1] ) + "/TileConfiguration.registered.txt" );
 
   // read coordinates from files
   std::ifstream fStage( std::string( argv[1] ) + "/TileConfiguration.txt" );

--- a/test/itkMontageTestOMC.cxx
+++ b/test/itkMontageTestOMC.cxx
@@ -41,9 +41,9 @@ int itkMontageTestOMC(int argc, char* argv[])
   PositionTableType stageCoords, actualCoords;
   FilenameTableType filenames;
 
-  std::vector< std::vector< Tile< 2 > > > tc =
-    parseTileConfiguration2D( std::string( argv[1] ) + "/TileConfiguration.txt" );
-  tc = parseTileConfiguration2D( std::string( argv[1] ) + "/TileConfiguration.registered.txt" );
+  std::vector< std::vector< itk::Tile< 2 > > > tc =
+    itk::ParseTileConfiguration2D( std::string( argv[1] ) + "/TileConfiguration.txt" );
+  tc = itk::ParseTileConfiguration2D( std::string( argv[1] ) + "/TileConfiguration.registered.txt" );
 
   // read coordinates from files
   std::ifstream fStage( std::string( argv[1] ) + "/TileConfiguration.txt" );


### PR DESCRIPTION
After commit 72d9ea6 I am running into:
`itkMontageTestOMC.obj : error LNK2019: unresolved external symbol "class std::vector<class std::vector<struct itk::Tile<2>,class std::allocator<struct itk::Tile<2> > >,class std::allocator<class std::vector<struct itk::Tile<2>,class std::allocator<struct itk::Tile<2> > > > > __cdecl itk::ParseTileConfiguration2D(class std::basic_string<char,struct std::char_traits<char>,class std::allocator<char> >)" (?ParseTileConfiguration2D@itk@@YA?AV?$vector@V?$vector@U?$Tile@$01@itk@@V?$allocator@U?$Tile@$01@itk@@@std@@@std@@V?$allocator@V?$vector@U?$Tile@$01@itk@@V?$allocator@U?$Tile@$01@itk@@@std@@@std@@@2@@std@@V?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@3@@Z) referenced in function "int __cdecl itkMontageTestOMC(int,char * * const)" (?itkMontageTestOMC@@YAHHQEAPEAD@Z)`

How to specify that Montage's tests should link to Montage library? Am I setting up the source part of the Module correctly?