### PR TITLE
Fixing incorrect Windows config file parsing on Mac

### DIFF
--- a/src/itkParseTileConfiguration.cxx
+++ b/src/itkParseTileConfiguration.cxx
@@ -39,6 +39,11 @@ getNextNonCommentLine( std::istream& in )
       break;
       }
     }
+
+  if ( temp[temp.size() - 1] == '\r' )
+  {
+    temp.erase(temp.size() - 1, 1);
+  }
   return temp;
 }
 


### PR DESCRIPTION
Added additional check to tile configuration parser that removes the carriage return character if it exists at the end of a line. This allows configuration files made in Windows to be read by Mac.