### PR TITLE
More comprehensive testing of registrations filter

### DIFF
--- a/include/itkTileMontage.hxx
+++ b/include/itkTileMontage.hxx
@@ -187,7 +187,7 @@ TileMontage< TImageType, TCoordinate >
 ::nDIndexToLinearIndex( TileIndexType nDIndex ) const
 {
   DataObjectPointerArraySizeType ind = 0;
-  SizeValueType                  stride = 1u;
+  SizeValueType stride = 1u;
   for ( unsigned d = 0; d < ImageDimension; d++ )
     {
     itkAssertOrThrowMacro( nDIndex[d] < m_MontageSize[d],
@@ -309,7 +309,7 @@ TileMontage< TImageType, TCoordinate >
           {
           TileIndexType referenceIndex = currentIndex;
           referenceIndex[regDim] = currentIndex[regDim] - 1;
-          TransformPointer      t = this->RegisterPair( referenceIndex, currentIndex );
+          TransformPointer t = this->RegisterPair( referenceIndex, currentIndex );
           TransformConstPointer oldT = this->GetTransform( referenceIndex );
           t->Compose( oldT, true );
           transforms.push_back( t );

--- a/src/itkParseTileConfiguration.cxx
+++ b/src/itkParseTileConfiguration.cxx
@@ -40,10 +40,10 @@ getNextNonCommentLine( std::istream& in )
       }
     }
 
-  if ( temp[temp.size() - 1] == '\r' )
-  {
+  if ( !temp.empty() && temp[temp.size() - 1] == '\r' )
+    {
     temp.erase(temp.size() - 1, 1);
-  }
+    }
   return temp;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -123,32 +123,42 @@ itk_add_test(NAME itkMontagePCMTestFilesSynthetic3D
     1.0
   )
 
-function(AddTestOMC slicerNumber)
+function(AddTestOMC slicerNumber inMemory)
   itk_add_test(NAME itkMontageTestOMC${slicerNumber}
     COMMAND MontageTestDriver
     itkMontageTest2D
       DATA{Input/OMC/FlatField/${slicerNumber}/,REGEX:.*}
       ${TESTING_OUTPUT_PATH}/itkMontageTestOMC${slicerNumber}_
       ${TESTING_OUTPUT_PATH}/itkMockMontageTestOMC${slicerNumber}_
-      1 -1 0 1
+      1 -1 ${inMemory} 1 0
     )
 endfunction()
 
-AddTestOMC(14)
-AddTestOMC(15)
-AddTestOMC(16)
-AddTestOMC(17)
-AddTestOMC(18)
+AddTestOMC(14 1)
+AddTestOMC(15 0)
+AddTestOMC(16 1)
+AddTestOMC(17 0)
+AddTestOMC(18 1)
 
-itk_add_test(NAME itkMontageTestRGB
+itk_add_test(NAME itkMontageTestRGBinMemory
   COMMAND MontageTestDriver
   --compare DATA{Input/VisibleHumanRGB/VisibleHumanMale1608.png}
-                 ${TESTING_OUTPUT_PATH}/itkMontageTestRGB0_1.mha
+                 ${TESTING_OUTPUT_PATH}/itkMontageTestRGBim0_1.mha
   itkMontageTest2D
     DATA{Input/VisibleHumanRGB/,REGEX:.*}
-    ${TESTING_OUTPUT_PATH}/itkMontageTestRGB
-    ${TESTING_OUTPUT_PATH}/itkMockMontageTestRGB
-    1 -1 1 1
+    ${TESTING_OUTPUT_PATH}/itkMontageTestRGBim
+    ${TESTING_OUTPUT_PATH}/itkMockMontageTestRGBim
+    1 -1 1 1 0
+  )
+itk_add_test(NAME itkMontageTestRGBpairs
+  COMMAND MontageTestDriver
+  --compare DATA{Input/VisibleHumanRGB/VisibleHumanMale1608.png}
+                 ${TESTING_OUTPUT_PATH}/itkMontageTestRGBp0_1.mha
+  itkMontageTest2D
+    DATA{Input/VisibleHumanRGB/,REGEX:.*}
+    ${TESTING_OUTPUT_PATH}/itkMontageTestRGBp
+    ${TESTING_OUTPUT_PATH}/itkMockMontageTestRGBp
+    1 -1 0 1 1
   )
 
 function(AddInMemoryMontageTest variation willFail)
@@ -210,7 +220,7 @@ if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/Input/Ti7/FlatFielded/36/1000.tif)
       ${flatFolder}
       ${TESTING_OUTPUT_PATH}/itkMontageTestTi7flat36_
       ${TESTING_OUTPUT_PATH}/itkMockMontageTestTi7flat36_
-      0 1 0 5
+      0 1 1 5 0
     )
 
   itk_add_test(NAME itkMontageTestTi7Slice36raw
@@ -219,7 +229,7 @@ if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/Input/Ti7/FlatFielded/36/1000.tif)
       ${rawFolder}
       ${TESTING_OUTPUT_PATH}/itkMontageTestTi7raw36_
       ${TESTING_OUTPUT_PATH}/itkMockMontageTestTi7raw36_
-      0 1 0 5
+      0 1 1 5 0
     )
 endif()
 
@@ -230,7 +240,7 @@ if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/Input/Tiles/Image_10_10.tif)
       ${CMAKE_CURRENT_LIST_DIR}/Input/Tiles
       ${TESTING_OUTPUT_PATH}/itkMontageTestTiles
       ${TESTING_OUTPUT_PATH}/itkMockMontageTestTiles
-      0 -1 1 1
+      0 -1 1 1 0
     )
 endif()
 
@@ -241,6 +251,6 @@ if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/Input/NoisyTiles/NoisyImage_10_10.tif)
       ${CMAKE_CURRENT_LIST_DIR}/Input/NoisyTiles
       ${TESTING_OUTPUT_PATH}/itkMontageTestNoisyTiles
       ${TESTING_OUTPUT_PATH}/itkMockMontageTestNoisyTiles
-      0 -1 1 1
+      0 -1 1 1 0
     )
 endif()

--- a/test/itkMontageTest2D.cxx
+++ b/test/itkMontageTest2D.cxx
@@ -26,7 +26,7 @@ int itkMontageTest2D(int argc, char* argv[])
   if ( argc < 4 )
     {
     std::cerr << "Usage: " << argv[0] << " <directoryWtihInputData> <montageTSV> <mockTSV>";
-    std::cerr << " [ varyPaddingMethods peakMethod loadIntoMemory streamSubdivisions ]" << std::endl;
+    std::cerr << " [ varyPaddingMethods peakMethod loadIntoMemory streamSubdivisions doPairs]" << std::endl;
     return EXIT_FAILURE;
     }
 
@@ -50,6 +50,11 @@ int itkMontageTest2D(int argc, char* argv[])
     {
     streamSubdivisions = std::stoul( argv[7] );
     }
+  bool doPairs = true;
+  if ( argc > 8 )
+    {
+    doPairs = std::stoi( argv[8] );
+    }
 
   std::string inputPath = argv[1];
   if ( inputPath.back() != '/' && inputPath.back() != '\\' )
@@ -66,22 +71,28 @@ int itkMontageTest2D(int argc, char* argv[])
   imageIO->ReadImageInformation();
   const itk::ImageIOBase::IOPixelType pixelType = imageIO->GetPixelType();
 
-  int r1, r2;
+  int r1, r2 = EXIT_SUCCESS;
   if (pixelType == itk::ImageIOBase::IOPixelType::RGB)
     {
     r1 = montageTest< itk::RGBPixel< unsigned char >, itk::RGBPixel< unsigned int > >(
       stageTiles, actualTiles, inputPath, argv[2],
       varyPaddingMethods, peakMethod, loadIntoMemory, streamSubdivisions );
-    r2 = mockMontageTest< unsigned char >(
-        stageTiles, actualTiles, inputPath, argv[3], varyPaddingMethods );
+    if ( doPairs )
+      {
+      r2 = mockMontageTest< unsigned char >(
+          stageTiles, actualTiles, inputPath, argv[3], varyPaddingMethods );
+      }
     }
   else
     {
     r1 = montageTest< unsigned short, double >(
       stageTiles, actualTiles, inputPath, argv[2],
       varyPaddingMethods, peakMethod, loadIntoMemory, streamSubdivisions );
-    r2 = mockMontageTest< unsigned short >(
-        stageTiles, actualTiles, inputPath, argv[3], varyPaddingMethods );
+    if ( doPairs )
+      {
+      r2 = mockMontageTest< unsigned short >(
+          stageTiles, actualTiles, inputPath, argv[3], varyPaddingMethods );
+      }
     }
 
   if ( r1 == EXIT_FAILURE || r2 == EXIT_FAILURE )

--- a/test/itkMontageTest2D.cxx
+++ b/test/itkMontageTest2D.cxx
@@ -16,8 +16,8 @@
  *
  *=========================================================================*/
 
-#include "itkMockMontageHelper.hxx"
 #include "itkMontageTestHelper.hxx"
+#include "itkPairwiseTestHelper.hxx"
 #include "itkParseTileConfiguration.h"
 #include "itkRGBPixel.h"
 
@@ -79,7 +79,7 @@ int itkMontageTest2D(int argc, char* argv[])
       varyPaddingMethods, peakMethod, loadIntoMemory, streamSubdivisions );
     if ( doPairs )
       {
-      r2 = mockMontageTest< unsigned char >(
+      r2 = pairwiseTests< unsigned char >(
           stageTiles, actualTiles, inputPath, argv[3], varyPaddingMethods );
       }
     }
@@ -90,7 +90,7 @@ int itkMontageTest2D(int argc, char* argv[])
       varyPaddingMethods, peakMethod, loadIntoMemory, streamSubdivisions );
     if ( doPairs )
       {
-      r2 = mockMontageTest< unsigned short >(
+      r2 = pairwiseTests< unsigned short >(
           stageTiles, actualTiles, inputPath, argv[3], varyPaddingMethods );
       }
     }

--- a/test/itkPairwiseTestHelper.hxx
+++ b/test/itkPairwiseTestHelper.hxx
@@ -132,8 +132,8 @@ calculateError( const itk::TileLayout2D& stageTiles, const itk::TileLayout2D& ac
 // do the registrations and calculate registration errors
 template< typename PixelType >
 int
-mockMontageTest( const itk::TileLayout2D& stageTiles, const itk::TileLayout2D& actualTiles,
-                 const std::string& inputPath, const std::string& outFilename, bool varyPaddingMethods )
+pairwiseTests( const itk::TileLayout2D& stageTiles, const itk::TileLayout2D& actualTiles,
+               const std::string& inputPath, const std::string& outFilename, bool varyPaddingMethods )
 {
   int result = EXIT_SUCCESS;
   constexpr unsigned Dimension = 2;


### PR DESCRIPTION
Enable more tests to use in-memory approach - it is slightly faster when padding and peak interpolation methods are varied.