### PR TITLE
COMP: Fix compiler warnings

### DIFF
--- a/examples/Montage2D.cxx
+++ b/examples/Montage2D.cxx
@@ -60,8 +60,8 @@ template< typename PixelType, typename AccumulatePixelType >
 void
 montage2D( const itk::TileLayout2D& stageTiles,
            const std::string& inputPath, const std::string& outputPath,
-           const std::string& outFilename, int peakMethodToUse,
-           bool setMontageDirectly, unsigned streamSubdivisions )
+           const std::string& outFilename, int itkNotUsed( peakMethodToUse ),
+           bool itkNotUsed( setMontageDirectly ), unsigned streamSubdivisions )
 {
   using ScalarPixelType = typename itk::NumericTraits< PixelType >::ValueType;
   constexpr unsigned Dimension = 2;
@@ -208,7 +208,7 @@ int main( int argc, char *argv[] )
     imageIO->SetFileName( inputPath + stageTiles[0][0].FileName );
     imageIO->ReadImageInformation();
 
-    const unsigned numDimensions = imageIO->GetNumberOfDimensions();
+    auto numDimensions = imageIO->GetNumberOfDimensions();
     if ( numDimensions != 2 )
       {
       itkGenericExceptionMacro( "Only 2D images are supported!" );

--- a/examples/RefineMontage2D.cxx
+++ b/examples/RefineMontage2D.cxx
@@ -29,13 +29,12 @@
 template< typename PixelType, typename AccumulatePixelType >
 void
 montage2D( const itk::TileLayout2D& stageTiles, itk::TileLayout2D& actualTiles,
-           const std::string& inputPath, int peakMethodToUse )
+           const std::string& inputPath, int itkNotUsed( peakMethodToUse ) )
 {
   using ScalarPixelType = typename itk::NumericTraits< PixelType >::ValueType;
   constexpr unsigned Dimension = 2;
   using TransformType = itk::TranslationTransform< double, Dimension >;
   using ScalarImageType = itk::Image< ScalarPixelType, Dimension >;
-  using OriginalImageType = itk::Image< PixelType, Dimension >; // possibly RGB instead of scalar
   using PCMType = itk::PhaseCorrelationImageRegistrationMethod< ScalarImageType, ScalarImageType >;
   typename ScalarImageType::SpacingType sp;
   sp.Fill( 1.0 ); // most data assumes unit spacing, even if the files themselves have something else (72 DPI, 96 DPI, 300 DPI etc)
@@ -95,8 +94,6 @@ int main( int argc, char *argv[] )
     return EXIT_FAILURE;
     }
 
-  constexpr unsigned Dimension = 2;
-
   std::string inputPath = itksys::SystemTools::GetFilenamePath( argv[1] );
   if ( !inputPath.empty() ) // a path was given in addition to file name
     {
@@ -113,7 +110,7 @@ int main( int argc, char *argv[] )
     imageIO->SetFileName( inputPath + stageTiles[0][0].FileName );
     imageIO->ReadImageInformation();
 
-    const unsigned numDimensions = imageIO->GetNumberOfDimensions();
+    auto numDimensions = imageIO->GetNumberOfDimensions();
     if ( numDimensions != 2 )
       {
       itkGenericExceptionMacro( "Only 2D images are supported!" );
@@ -129,7 +126,7 @@ int main( int argc, char *argv[] )
         case itk::ImageIOBase::IOComponentType::USHORT:
           montage2D< unsigned short, double >( stageTiles, actualTiles, inputPath, 1 );
           break;
-        default: // instantiating too many types leads to long compileation time and big executable
+        default: // instantiating too many types leads to long compilation time and big executable
           itkGenericExceptionMacro( "Only unsigned char and unsigned short are supported!" );
           break;
       }

--- a/test/itkInMemoryMontageTestHelper.hxx
+++ b/test/itkInMemoryMontageTestHelper.hxx
@@ -289,11 +289,11 @@ private:
     for ( itk::TileRow2D tileRow : stageTiles )
       {
       OriginRow row;
-      for ( int col = 0; col < tileRow.size(); col++ )
+      for ( unsigned col = 0; col < tileRow.size(); col++ )
         {
         itk::Tile2D tile = tileRow[col];
         itk::Point< double, Dimension > pos = tile.Position;
-        for ( int i = 0; i < Dimension; i++ )
+        for ( unsigned i = 0; i < Dimension; i++ )
           {
           // Get correct origin value, then add [col * 100] to it
           pos[i] = pos[i] + ( col * 100 );
@@ -342,11 +342,11 @@ private:
     for ( itk::TileRow2D tileRow : stageTiles )
       {
       OriginRow row;
-      for ( int col = 0; col < tileRow.size(); col++ )
+      for ( unsigned col = 0; col < tileRow.size(); col++ )
         {
         itk::Tile2D tile = tileRow[col];
         itk::Point< double, Dimension > pos = tile.Position;
-        for ( int i = 0; i < Dimension; i++ )
+        for ( unsigned i = 0; i < Dimension; i++ )
           {
           // Get correct origin value, divide by 2 to account for the 0.5 spacing, then add [col * 100]
           pos[i] = ( pos[i] / 2 ) + ( col * 100 );
@@ -448,7 +448,7 @@ private:
     Origin2D UO;
 
     OriginPoint UO_point;
-    for ( int i = 0; i < Dimension; i++ )
+    for ( unsigned i = 0; i < Dimension; i++ )
       {
       UO_point[i] = 0;
       }
@@ -490,7 +490,7 @@ private:
     Spacing2D US;
 
     SpacingType spacing;
-    for ( int i = 0; i < Dimension; i++ )
+    for ( unsigned i = 0; i < Dimension; i++ )
       {
       spacing[i] = value;
       }


### PR DESCRIPTION
Fix compiler warnings:
- Remove unused type aliases.
- Use the `itkNotUsed` macro for unused function arguments.
- Use the appropriate types for local counter variables in `for` loops.

Fixes:
```
Modules/Remote/Montage/examples/RefineMontage2D.cxx:38:63: warning:
typedef 'using OriginalImageType = class itk::Image<PixelType, 2u>'
locally defined but not used [-Wunused-local-typedefs]

```
,
```
Modules/Remote/Montage/examples/RefineMontage2D.cxx:32:46: warning: unused
parameter 'peakMethodToUse' [-Wunused-parameter]
             const std::string& inputPath, int peakMethodToUse )
	                                       ^
```

and
```
Modules/Remote/Montage/test/itkInMemoryMontageTestHelper.hxx:292:30:
warning: comparison between signed and unsigned integer expressions
[-Wsign-compare]
        for ( int col = 0; col < tileRow.size(); col++ )
	                       ^
```

errors.

Reported at:
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5820589