### PR TITLE
COMP: Fix unused variable warning

### DIFF
--- a/include/itkMaxPhaseCorrelationOptimizer.hxx
+++ b/include/itkMaxPhaseCorrelationOptimizer.hxx
@@ -302,7 +302,7 @@ MaxPhaseCorrelationOptimizer< TRegistrationMethod >
     indices.resize( this->m_Offsets.size() );
     }
 
-  double confidenceFactor = 1.0 / this->m_Confidences[0];
+  // double confidenceFactor = 1.0 / this->m_Confidences[0];
 
   for ( unsigned m = 0; m < this->m_Confidences.size(); m++ )
     {


### PR DESCRIPTION
Fix unused variable warning.

Fixes:
```
Modules/Remote/Montage/include/itkMaxPhaseCorrelationOptimizer.hxx:305:10:
warning: unused variable 'confidenceFactor' [-Wunused-variable]
```

raised at:
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5914663