### PR TITLE
Improve coarse-grained parallelism

### DIFF
--- a/include/itkMaxPhaseCorrelationOptimizer.h
+++ b/include/itkMaxPhaseCorrelationOptimizer.h
@@ -88,6 +88,12 @@ public:
   };
   itkGetConstMacro( PeakInterpolationMethod, PeakInterpolationMethod );
   void SetPeakInterpolationMethod( const PeakInterpolationMethod peakInterpolationMethod );
+  friend std::ostream&
+  operator<<( std::ostream& os, const PeakInterpolationMethod& pim )
+  {
+    os << static_cast< typename std::underlying_type< PeakInterpolationMethod >::type >( pim );
+    return os;
+  }
 
   /** Get/Set maximum city-block distance for peak merging. Zero disables it. */
   itkGetConstMacro( MergePeaks, unsigned );

--- a/include/itkMaxPhaseCorrelationOptimizer.hxx
+++ b/include/itkMaxPhaseCorrelationOptimizer.hxx
@@ -42,8 +42,7 @@ MaxPhaseCorrelationOptimizer< TRegistrationMethod >
 {
   Superclass::PrintSelf( os, indent );
   os << indent << "MaxCalculator: " << m_MaxCalculator << std::endl;
-  auto pim = static_cast< typename std::underlying_type< PeakInterpolationMethod >::type >( m_PeakInterpolationMethod );
-  os << indent << "PeakInterpolationMethod: " << pim << std::endl;
+  os << indent << "PeakInterpolationMethod: " << m_PeakInterpolationMethod << std::endl;
   os << indent << "MergePeaks: " << m_MergePeaks << std::endl;
   os << indent << "ZeroSuppression: " << m_ZeroSuppression << std::endl;
   os << indent << "PixelDistanceTolerance: " << m_PixelDistanceTolerance << std::endl;

--- a/include/itkPhaseCorrelationImageRegistrationMethod.h
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.h
@@ -254,6 +254,12 @@ public:
   };
   itkGetConstMacro( PaddingMethod, PaddingMethod );
   void SetPaddingMethod( const PaddingMethod paddingMethod );
+  friend std::ostream&
+  operator<<( std::ostream& os, const PaddingMethod& pm )
+  {
+    os << static_cast< typename std::underlying_type< PaddingMethod >::type >( pm );
+    return os;
+  }
 
   /** Set/Get tile cropping. Should tiles be cropped to overlapping
    * region for computing the cross correlation? Default: True.

--- a/include/itkPhaseCorrelationImageRegistrationMethod.hxx
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.hxx
@@ -528,7 +528,7 @@ PhaseCorrelationImageRegistrationMethod< TFixedImage, TMovingImage, TInternalPix
 
   os << indent << "Pad To Size: " << m_PadToSize << std::endl;
   os << indent << "Obligatory Padding: " << m_ObligatoryPadding << std::endl;
-  os << indent << "Padding Method: " << int( m_PaddingMethod ) << std::endl;
+  os << indent << "Padding Method: " << m_PaddingMethod << std::endl;
 
   os << indent << "Crop To Overlap: " << m_CropToOverlap << std::endl;
   os << indent << "Butterworth Order: " << m_ButterworthOrder << std::endl;

--- a/include/itkTileMergeImageFilter.h
+++ b/include/itkTileMergeImageFilter.h
@@ -24,9 +24,6 @@
 #include "itkLinearInterpolateImageFunction.h"
 #include "itkNumericTraits.h"
 
-#include <deque>
-#include <mutex>
-
 namespace itk
 {
 /** \class TileMergeImageFilter
@@ -163,7 +160,7 @@ public:
 
 protected:
   TileMergeImageFilter();
-  virtual ~TileMergeImageFilter(){};
+  virtual ~TileMergeImageFilter() = default;
   void PrintSelf( std::ostream& os, Indent indent ) const override;
 
   /** Method invoked by the pipeline in order to trigger the computation of the registration. */
@@ -179,9 +176,6 @@ protected:
   {
     return ImageType::New();
   }
-
-  /** For reading if only filename was given. */
-  using ReaderType = ImageFileReader< ImageType >;
 
   /** If not already read, reads the image into memory.
    * Only the part which overlaps output image's requested region is read.
@@ -215,8 +209,6 @@ private:
   PixelType m_Background = PixelType(); // default background value (not covered by any input tile)
 
   std::vector<TransformConstPointer> m_Transforms;
-  std::deque<std::mutex>             m_TileReadLocks; //to avoid reading the same tile by more than one thread in parallel
-  //deque is not reallocated when resized, so no mutex moving causing a crash
   std::vector<ImagePointer>          m_Tiles; // metadata/image storage (if filenames are given instead of actual images)
   typename Superclass::ConstPointer  m_Montage;
   std::vector<RegionType>            m_InputMappings; //where do input tile regions map into the output

--- a/include/itkTileMergeImageFilter.hxx
+++ b/include/itkTileMergeImageFilter.hxx
@@ -138,7 +138,6 @@ TileMergeImageFilter< TImageType, TPixelAccumulateType, TInterpolator >
   Superclass::SetMontageSize( montageSize );
   m_Transforms.resize( this->m_LinearMontageSize );
   m_Tiles.resize( this->m_LinearMontageSize );
-  m_TileReadLocks.resize( this->m_LinearMontageSize );
   this->SetNumberOfRequiredOutputs( 1 );
 }
 
@@ -250,7 +249,7 @@ TileMergeImageFilter< TImageType, TPixelAccumulateType, TInterpolator >
 
   ImagePointer outputImage = this->GetOutput();
   RegionType reqR = outputImage->GetRequestedRegion();
-  std::lock_guard< std::mutex > lockGuard( m_TileReadLocks[linearIndex] );
+  std::lock_guard< std::mutex > lockGuard( this->m_TileReadLocks[linearIndex] );
   if ( m_Tiles[linearIndex].IsNotNull() )
     {
     RegionType r = m_Tiles[linearIndex]->GetBufferedRegion();
@@ -261,7 +260,7 @@ TileMergeImageFilter< TImageType, TPixelAccumulateType, TInterpolator >
     }
 
   bool onlyMetadata = ( wantedRegion.GetNumberOfPixels() == 0 );
-  m_Tiles[linearIndex] = Superclass::template GetImageHelper< ImageType >( nDIndex, onlyMetadata, reqR, nullptr );
+  m_Tiles[linearIndex] = Superclass::template GetImageHelper< ImageType >( nDIndex, onlyMetadata, reqR );
   return m_Tiles[linearIndex];
 }
 
@@ -444,8 +443,8 @@ TileMergeImageFilter< TImageType, TPixelAccumulateType, TInterpolator >
     return; // nothing to do
     }
   bool interpolate = true;
-  if ( m_Montage.IsNotNull() && m_Montage->m_PCMOptimizer->GetPeakInterpolationMethod() ==
-                                  Superclass::PCMOptimizerType::PeakInterpolationMethod::None )
+  if ( m_Montage.IsNotNull() && m_Montage->GetPeakInterpolationMethod() ==
+       Superclass::PCMOptimizerType::PeakInterpolationMethod::None )
     {
     interpolate = false;
     // TODO: replace this by a check whether all the

--- a/include/itkTileMergeImageFilter.hxx
+++ b/include/itkTileMergeImageFilter.hxx
@@ -442,16 +442,7 @@ TileMergeImageFilter< TImageType, TPixelAccumulateType, TInterpolator >
     {
     return; // nothing to do
     }
-  bool interpolate = true;
-  if ( m_Montage.IsNotNull() && m_Montage->GetPeakInterpolationMethod() ==
-       Superclass::PCMOptimizerType::PeakInterpolationMethod::None )
-    {
-    interpolate = false;
-    // TODO: replace this by a check whether all the
-    // origins+transforms are divisible by spacing (within tolerance)
-    }
   ImageRegionIteratorWithIndex< ImageType > oIt( outputImage, currentRegion );
-
   if ( m_RegionContributors[i].empty() ) // not covered by any tile
     {
     while ( !oIt.IsAtEnd() )
@@ -459,35 +450,73 @@ TileMergeImageFilter< TImageType, TPixelAccumulateType, TInterpolator >
       oIt.Set( m_Background );
       ++oIt;
       }
+    return;
     }
-  else if ( m_RegionContributors[i].size() == 1 ) // just one tile
-    {
-    SizeValueType tileIndex = *m_RegionContributors[i].begin();
-    TileIndexType nDIndex = this->LinearIndexTonDIndex( tileIndex );
-    OffsetType tileToRegion = currentRegion.GetIndex() - m_InputMappings[tileIndex].GetIndex();
-    RegionType inRegion = currentRegion;
-    ImageConstPointer input = this->GetImage( nDIndex, reg0 ); // matadata (at least)
-    inRegion.SetIndex( input->GetLargestPossibleRegion().GetIndex() + tileToRegion );
-    input = this->GetImage( nDIndex, inRegion ); // metadata + at least inRegion of data
 
+  using ContinuousValueType = typename ContinuousIndexType::ValueType;
+  std::vector< SizeValueType > tileIndices( m_RegionContributors[i].begin(), m_RegionContributors[i].end() );
+  const unsigned nTiles = tileIndices.size();
+  std::vector< ImageConstPointer > inputs( nTiles );
+  std::vector< RegionType* > tileRegions( nTiles );
+  std::vector< RegionType > inRegions( nTiles );
+  std::vector< Vector< ContinuousValueType, ImageDimension > > continuousIndexDifferences( nTiles );
+  for ( unsigned t = 0; t < nTiles; t++ )
+    {
+    TileIndexType nDIndex = this->LinearIndexTonDIndex( tileIndices[t] );
+    OffsetType tileToRegion = currentRegion.GetIndex() - m_InputMappings[tileIndices[t]].GetIndex();
+    inRegions[t] = currentRegion;
+    ImageConstPointer input = this->GetImage( nDIndex, reg0 ); // matadata (at least)
+    inRegions[t].SetIndex( input->GetLargestPossibleRegion().GetIndex() + tileToRegion );
+    inputs[t] = this->GetImage( nDIndex, inRegions[t] ); // metadata + at least inRegions[t] of data
+    tileRegions[t] = &m_InputMappings[tileIndices[t]];
+    for ( unsigned d = 0; d < ImageDimension; d++ )
+      {
+      continuousIndexDifferences[t][d] =
+        inputs[t]->GetLargestPossibleRegion().GetIndex( d ) - m_InputsContinuousIndices[tileIndices[t]][d];
+      }
+    }
+
+  ContinuousValueType eps = 1e-4;
+  typename ImageType::SpacingType spacing = outputImage->GetSpacing();
+  bool interpolate = false;
+  if ( m_Montage.IsNotNull() ) // we can check whether interpolation was used
+    {
+    const auto InterpolationNone = Superclass::PCMOptimizerType::PeakInterpolationMethod::None;
+    interpolate = ( m_Montage->GetPeakInterpolationMethod() != InterpolationNone );
+    }
+  else // examine alignment of image grids of all the contributing regions
+    {
+    const typename ImageType::PointType oOrigin = outputImage->GetOrigin();
+    for ( unsigned t = 0; t < nTiles; t++ )
+      {
+      const typename ImageType::PointType iOrigin = inputs[t]->GetOrigin();
+      for ( unsigned d = 0; d < ImageDimension; d++ )
+        {
+        ContinuousValueType translation = ( oOrigin[d] - iOrigin[d] ) / spacing[d] + continuousIndexDifferences[t][d];
+        ContinuousValueType absDiff = std::abs( translation - std::round( translation ) );
+        if ( absDiff > eps )
+          {
+          interpolate = true;
+          break;
+          }
+        }
+      }
+    }
+
+  if ( nTiles == 1 ) // blending not needed
+    {
     if ( !interpolate )
       {
-      ImageAlgorithm::Copy( input.GetPointer(), outputImage.GetPointer(), inRegion, currentRegion );
+      ImageAlgorithm::Copy( inputs[0].GetPointer(), outputImage.GetPointer(), inRegions[0], currentRegion );
       }
     else
       {
-      Vector< typename ContinuousIndexType::ValueType, ImageDimension > continuousIndexDifference;
-      for ( unsigned d = 0; d < ImageDimension; d++ )
-        {
-        continuousIndexDifference[d] =
-          input->GetLargestPossibleRegion().GetIndex( d ) - m_InputsContinuousIndices[tileIndex][d];
-        }
       typename TInterpolator::Pointer interp = TInterpolator::New();
-      interp->SetInputImage( input );
+      interp->SetInputImage( inputs[0] );
       while ( !oIt.IsAtEnd() )
         {
         ContinuousIndexType continuousIndex = oIt.GetIndex();
-        continuousIndex += continuousIndexDifference;
+        continuousIndex += continuousIndexDifferences[0];
         oIt.Set( interp->EvaluateAtContinuousIndex( continuousIndex ) );
         ++oIt;
         }
@@ -495,24 +524,7 @@ TileMergeImageFilter< TImageType, TPixelAccumulateType, TInterpolator >
     }
   else // more than one tile contributes
     {
-    std::vector< SizeValueType > tileIndices( m_RegionContributors[i].begin(), m_RegionContributors[i].end() );
-    unsigned nTiles = tileIndices.size();
-    std::vector< ImageConstPointer > inputs( nTiles );
-    std::vector< RegionType* > tileRegions( nTiles );
-    std::vector< RegionType > inRegions( nTiles );
-    for ( unsigned t = 0; t < nTiles; t++ )
-      {
-      TileIndexType nDIndex = this->LinearIndexTonDIndex( tileIndices[t] );
-      OffsetType tileToRegion = currentRegion.GetIndex() - m_InputMappings[tileIndices[t]].GetIndex();
-      inRegions[t] = currentRegion;
-      ImageConstPointer input = this->GetImage( nDIndex, reg0 ); // matadata (at least)
-      inRegions[t].SetIndex( input->GetLargestPossibleRegion().GetIndex() + tileToRegion );
-      inputs[t] = this->GetImage( nDIndex, inRegions[t] ); // metadata + at least inRegions[t] of data
-      tileRegions[t] = &m_InputMappings[tileIndices[t]];
-      }
-
-    TPixelAccumulateType zeroSum = NumericTraits< TPixelAccumulateType >::ZeroValue();
-
+    const TPixelAccumulateType zeroSum = NumericTraits< TPixelAccumulateType >::ZeroValue();
     if ( !interpolate )
       {
       std::vector< ImageRegionConstIterator< ImageType > > iIt( nTiles );
@@ -541,7 +553,6 @@ TileMergeImageFilter< TImageType, TPixelAccumulateType, TInterpolator >
     else
       {
       std::vector< typename TInterpolator::Pointer > iInt( nTiles );
-      std::vector< Vector< typename ContinuousIndexType::ValueType, ImageDimension > > continuousIndexDifferences( nTiles );
       for ( unsigned t = 0; t < nTiles; t++ )
         {
         for ( unsigned d = 0; d < ImageDimension; d++ )

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,26 +20,28 @@ itk_add_test(NAME itkMontageGenericTests
 set(SyntheticOutputPath "${TESTING_OUTPUT_PATH}/synthetic")
 file(MAKE_DIRECTORY ${SyntheticOutputPath})
 
-function(AddTestSynthetic dimTTcode)
+function(AddTestSynthetic dimTTcode startSize endSize)
   itk_add_test(NAME itkMontagePCMSynthetic_${dimTTcode}
     COMMAND MontageTestDriver
     itkMontagePCMTestSynthetic
       ${dimTTcode}
       ${SyntheticOutputPath}/itkMontagePCMSynthetic_${dimTTcode}.nrrd
       ${SyntheticOutputPath}/itkMontagePCMSynthetic_${dimTTcode}.tfm
+      ${startSize}
+      ${endSize}
     )
 endfunction()
 
-AddTestSynthetic(2cc)
-AddTestSynthetic(2ff)
-AddTestSynthetic(2dd)
-AddTestSynthetic(2cf)
-AddTestSynthetic(2fd)
-AddTestSynthetic(3cc)
-AddTestSynthetic(3ff)
-AddTestSynthetic(3dd)
-AddTestSynthetic(3cf)
-AddTestSynthetic(3fd)
+AddTestSynthetic(2cc  21 23)
+AddTestSynthetic(2ff  17 19)
+AddTestSynthetic(2dd  17 51)
+AddTestSynthetic(2cf  11 13)
+AddTestSynthetic(2fd  51 71)
+AddTestSynthetic(3cc  21 23)
+AddTestSynthetic(3ff  17 19)
+AddTestSynthetic(3dd  31 47)
+AddTestSynthetic(3cf  11 13)
+AddTestSynthetic(3fd  19 21)
 
 
 itk_add_test(NAME itkMontagePCMSynthetic_ShouldFail
@@ -48,6 +50,7 @@ itk_add_test(NAME itkMontagePCMSynthetic_ShouldFail
     2cc
     ${TESTING_OUTPUT_PATH}/itkMontagePCMSynthetic_ShouldNotExist.nrrd
     ${TESTING_OUTPUT_PATH}/itkMontagePCMSynthetic_ShouldNotExist.tfm
+    17 19
     0.9 1.1
   )
 set_tests_properties(itkMontagePCMSynthetic_ShouldFail PROPERTIES WILL_FAIL TRUE)

--- a/test/itkInMemoryMontageTestHelper.hxx
+++ b/test/itkInMemoryMontageTestHelper.hxx
@@ -141,7 +141,6 @@ private:
   using Origin2D = std::vector< OriginRow >;
   using OriginalImageType = itk::Image< PixelType, Dimension >; // possibly RGB instead of scalar
   using PCMType = itk::PhaseCorrelationImageRegistrationMethod< ScalarImageType, ScalarImageType >;
-  using PadMethodUnderlying = typename std::underlying_type< typename PCMType::PaddingMethod >::type;
   using TransformType = itk::TranslationTransform< double, Dimension >;
   using StageTiles = itk::TileLayout2D;
 

--- a/test/itkMontageGenericTests.cxx
+++ b/test/itkMontageGenericTests.cxx
@@ -39,26 +39,26 @@ int itkMontageGenericTests( int, char** const )
   using SizeType = typename MergingTypeF::SizeType;
 
   OperatorType::Pointer pcmOperator = OperatorType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( pcmOperator, PhaseCorrelationOperator, ImageToImageFilter );
-  TRY_EXPECT_EXCEPTION( pcmOperator->Update() ); // inputs not set!
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( pcmOperator, PhaseCorrelationOperator, ImageToImageFilter );
+  ITK_TRY_EXPECT_EXCEPTION( pcmOperator->Update() ); // inputs not set!
   OptimizerType::Pointer pcmOptimizer = OptimizerType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( pcmOptimizer, MaxPhaseCorrelationOptimizer, PhaseCorrelationOptimizer );
-  TRY_EXPECT_EXCEPTION( pcmOptimizer->Update() ); // inputs not set!
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( pcmOptimizer, MaxPhaseCorrelationOptimizer, PhaseCorrelationOptimizer );
+  ITK_TRY_EXPECT_EXCEPTION( pcmOptimizer->Update() ); // inputs not set!
   PCMType::Pointer pcm = PCMType::New();
-  EXERCISE_BASIC_OBJECT_METHODS( pcm, PhaseCorrelationImageRegistrationMethod, ProcessObject );
-  TRY_EXPECT_EXCEPTION( pcm->Update() ); // inputs not set!
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( pcm, PhaseCorrelationImageRegistrationMethod, ProcessObject );
+  ITK_TRY_EXPECT_EXCEPTION( pcm->Update() ); // inputs not set!
   MontageTypeD::Pointer tmD = MontageTypeD::New();
-  EXERCISE_BASIC_OBJECT_METHODS( tmD, TileMontage, ProcessObject );
-  TRY_EXPECT_EXCEPTION( tmD->Update() ); // inputs not set!
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( tmD, TileMontage, ProcessObject );
+  ITK_TRY_EXPECT_EXCEPTION( tmD->Update() ); // inputs not set!
   MontageTypeF::Pointer tmF = MontageTypeF::New();
-  EXERCISE_BASIC_OBJECT_METHODS( tmF, TileMontage, ProcessObject );
-  TRY_EXPECT_EXCEPTION( tmF->Update() ); // inputs not set!
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( tmF, TileMontage, ProcessObject );
+  ITK_TRY_EXPECT_EXCEPTION( tmF->Update() ); // inputs not set!
   MergingTypeD::Pointer mtD = MergingTypeD::New();
-  EXERCISE_BASIC_OBJECT_METHODS( mtD, TileMergeImageFilter, TileMontage );
-  TRY_EXPECT_EXCEPTION( mtD->Update() ); // inputs not set!
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( mtD, TileMergeImageFilter, TileMontage );
+  ITK_TRY_EXPECT_EXCEPTION( mtD->Update() ); // inputs not set!
   MergingTypeF::Pointer mtF = MergingTypeF::New();
-  EXERCISE_BASIC_OBJECT_METHODS( mtF, TileMergeImageFilter, TileMontage );
-  TRY_EXPECT_EXCEPTION( mtF->Update() ); // inputs not set!
+  ITK_EXERCISE_BASIC_OBJECT_METHODS( mtF, TileMergeImageFilter, TileMontage );
+  ITK_TRY_EXPECT_EXCEPTION( mtF->Update() ); // inputs not set!
 
   // exercise nD index conversions
   SizeType size = { 2, 3, 4, 5 };
@@ -69,7 +69,7 @@ int itkMontageGenericTests( int, char** const )
   mtF->SetTileTransform( ind0, nullptr );
   mtF->SetTileTransform( ind1, nullptr );
   mtF->SetTileTransform( ind2, nullptr );
-  TEST_SET_GET_BOOLEAN( mtF, CropToFill, true );
+  ITK_TEST_SET_GET_BOOLEAN( mtF, CropToFill, true );
 
   return EXIT_SUCCESS;
 }

--- a/test/itkMontagePCMTestSynthetic.cxx
+++ b/test/itkMontagePCMTestSynthetic.cxx
@@ -112,14 +112,16 @@ public:
 template< unsigned int VDimension, typename TFixedImagePixel, typename TMovingImagePixel >
 int PhaseCorrelationRegistration( int argc, char* argv[] )
 {
-  if ( argc < 4 )
+  if ( argc < 6 )
     {
     std::cerr << "Usage: " << argv[0] << " <<dimension><fixedTypeChar><movingTypeChar>>";
-    std::cerr << "<phaseCorrelationFile> <transformFile> [movingImageSpacings]" << std::endl;
-    std::cerr << "e.g.\n\t" << argv[0] << " 2cf phase.nrrd transform.tfm 1.0 1.0" << std::endl;
+    std::cerr << " <phaseCorrelationFile> <transformFile> <startSize> <endSize> [movingImageSpacings]" << std::endl;
+    std::cerr << "e.g.\n\t" << argv[0] << " 2cf phase.nrrd transform.tfm 17 31 1.0 1.0" << std::endl;
     return EXIT_FAILURE;
     }
   const char* phaseCorrelationFile = argv[2];
+  unsigned startSize = std::stoul(argv[4]);
+  unsigned endSize = std::stoul(argv[5]);
 
   using FixedImageType = itk::Image< TFixedImagePixel, VDimension >;
   using MovingImageType = itk::Image< TMovingImagePixel, VDimension >;
@@ -149,7 +151,7 @@ int PhaseCorrelationRegistration( int argc, char* argv[] )
   std::vector< TestCoefficientsType > testCoefficients = { { 2.0, -0.1, 0.05, 0.1, -2.1 },
                                                            { 2.5, -0.3, 0.05, 0.15, 2.15 } };
 
-  for ( unsigned size1 = 17; size1 <= 31; size1++ )
+  for ( unsigned size1 = startSize; size1 <= endSize; size1++ )
     {
     std::cout << "\nSize " << size1 << std::endl;
     for ( const auto& coef : testCoefficients )
@@ -177,9 +179,9 @@ int PhaseCorrelationRegistration( int argc, char* argv[] )
         movingImageSource->m_SphereCenter[i] += actualParameters[i];
         movingOrigin[i] = size1 * coef[3] + i * coef[4];
         // movingSpacing[i] = 1.0 / (0.8 + i); //test different spacing (unsupported)
-        if ( argc > 4 + int( i ) )
+        if ( argc > 6 + int( i ) )
           {
-          movingSpacing[i] = std::stod( argv[4 + i] );
+          movingSpacing[i] = std::stod( argv[6 + i] );
           }
         movingSize[i] = (unsigned long)( size[i] / movingSpacing[i] + 3 * std::pow( -1, i ) );
         movingSize[i] = std::max< itk::SizeValueType >( movingSize[i], 7u );
@@ -239,7 +241,7 @@ int PhaseCorrelationRegistration( int argc, char* argv[] )
           ParametersType transformParameters = pcm->GetOutput()->Get()->GetParameters();
 
           const unsigned int numberOfParameters = actualParameters.Size();
-          const double       tolerance = 1.0 + 1e-6;
+          const double tolerance = 1.0 + 1e-6;
 
           // Validate the translation parameters
           for ( unsigned int i = 0; i < numberOfParameters; i++ )

--- a/test/itkMontageTestHelper.hxx
+++ b/test/itkMontageTestHelper.hxx
@@ -194,13 +194,15 @@ montageTest( const itk::TileLayout2D& stageTiles, const itk::TileLayout2D& actua
 
     typename MontageType::Pointer montage = MontageType::New();
     auto paddingMethod = static_cast< typename PCMType::PaddingMethod >( padMethod );
-    montage->GetModifiablePCM()->SetPaddingMethod( paddingMethod );
+    montage->SetPaddingMethod( paddingMethod );
     montage->SetPositionTolerance( positionTolerance );
     montage->SetMontageSize( { xMontageSize, yMontageSize } );
     if ( !loadIntoMemory )
       {
       montage->SetOriginAdjustment( originAdjustment );
       montage->SetForcedSpacing( sp );
+      // Set full coarse-grained parallelism. It helps with decoding JPEG images.
+      montage->SetNumberOfWorkUnits( itk::MultiThreaderBase::GetGlobalDefaultNumberOfThreads() );
       }
 
     for ( unsigned y = 0; y < yMontageSize; y++ )
@@ -229,11 +231,7 @@ montageTest( const itk::TileLayout2D& stageTiles, const itk::TileLayout2D& actua
         {
         peakMethod = static_cast< PeakFinderUnderlying >( peakMethodToUse );
         }
-      montage->GetModifiablePCMOptimizer()->SetPeakInterpolationMethod(
-        static_cast< PeakInterpolationType >( peakMethod ) );
-      montage->Modified(); // optimizer is not an "input" to PCM
-      // so its modification does not cause a pipeline update automatically
-
+      montage->SetPeakInterpolationMethod( static_cast< PeakInterpolationType >( peakMethod ) );
       std::cout << "    PeakMethod " << peakMethod << std::endl;
       itk::SimpleFilterWatcher fw( montage, "montage" );
       // montage->SetDebug( true ); // enable more debugging output from global tile optimization


### PR DESCRIPTION
This makes better use of available processing power, by overlapping different phases of computation: memory-bound, cache-bound (and if tiles are not in memory, IO).