### PR TITLE
COMP: Change old enum to new enum class definitions

### DIFF
--- a/examples/Montage2D.cxx
+++ b/examples/Montage2D.cxx
@@ -200,7 +200,7 @@ int main( int argc, char *argv[] )
     // but we examine what is the input type of the first tile and instantiate that
 
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        (inputPath + stageTiles[0][0].FileName).c_str(), itk::ImageIOFactory::ReadMode );
+        (inputPath + stageTiles[0][0].FileName).c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     imageIO->SetFileName( inputPath + stageTiles[0][0].FileName );
     imageIO->ReadImageInformation();
 

--- a/examples/RefineMontage2D.cxx
+++ b/examples/RefineMontage2D.cxx
@@ -112,7 +112,7 @@ int main( int argc, char *argv[] )
   try
     {
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        (inputPath + stageTiles[0][0].FileName).c_str(), itk::ImageIOFactory::ReadMode );
+        (inputPath + stageTiles[0][0].FileName).c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     imageIO->SetFileName( inputPath + stageTiles[0][0].FileName );
     imageIO->ReadImageInformation();
 

--- a/examples/ResampleMontage2D.cxx
+++ b/examples/ResampleMontage2D.cxx
@@ -122,7 +122,7 @@ int main( int argc, char *argv[] )
   try
     {
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-      ( inputPath + actualTiles[0][0].FileName ).c_str(), itk::ImageIOFactory::ReadMode );
+      ( inputPath + actualTiles[0][0].FileName ).c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
     imageIO->SetFileName( inputPath + actualTiles[0][0].FileName );
     imageIO->ReadImageInformation();
 

--- a/test/itkInMemoryMontageTest2D.cxx
+++ b/test/itkInMemoryMontageTest2D.cxx
@@ -45,7 +45,7 @@ itkInMemoryMontageTest2D( int argc, char* argv[] )
   itk::TileLayout2D stageTiles = itk::ParseTileConfiguration2D( inputPath + "TileConfiguration.registered.txt" );
 
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-    ( inputPath + stageTiles[0][0].FileName ).c_str(), itk::ImageIOFactory::ReadMode );
+    ( inputPath + stageTiles[0][0].FileName ).c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
   imageIO->SetFileName( inputPath + stageTiles[0][0].FileName );
   imageIO->ReadImageInformation();
   const itk::ImageIOBase::IOPixelType pixelType = imageIO->GetPixelType();

--- a/test/itkMontagePCMTestFiles.cxx
+++ b/test/itkMontagePCMTestFiles.cxx
@@ -158,7 +158,7 @@ int itkMontagePCMTestFiles( int argc, char* argv[] )
   try
     {
     itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-        argv[1], itk::ImageIOFactory::ReadMode);
+        argv[1], itk::ImageIOFactory::FileModeType::ReadMode);
     imageIO->SetFileName( argv[1] );
     imageIO->ReadImageInformation();
     // const itk::ImageIOBase::IOComponentType pixelType = imageIO->GetComponentType();

--- a/test/itkMontageTest2D.cxx
+++ b/test/itkMontageTest2D.cxx
@@ -87,7 +87,7 @@ int itkMontageTest2D(int argc, char* argv[])
   itk::TileLayout2D actualTiles = itk::ParseTileConfiguration2D( inputPath + "TileConfiguration.registered.txt" );
 
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-    ( inputPath + stageTiles[0][0].FileName ).c_str(), itk::ImageIOFactory::ReadMode );
+    ( inputPath + stageTiles[0][0].FileName ).c_str(), itk::ImageIOFactory::FileModeType::ReadMode );
   imageIO->SetFileName( inputPath + stageTiles[0][0].FileName );
   imageIO->ReadImageInformation();
   const itk::ImageIOBase::IOPixelType pixelType = imageIO->GetPixelType();

--- a/test/itkMontageTruthCreator.cxx
+++ b/test/itkMontageTruthCreator.cxx
@@ -218,7 +218,7 @@ int itkMontageTruthCreator( int argc, char* argv[] )
     return EXIT_FAILURE;
     }
 
-  itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO( argv[1], itk::ImageIOFactory::ReadMode );
+  itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO( argv[1], itk::ImageIOFactory::FileModeType::ReadMode );
   imageIO->SetFileName( argv[1] );
   imageIO->ReadImageInformation();
   unsigned dim = imageIO->GetNumberOfDimensions();


### PR DESCRIPTION
When ITK is configured with the following:

- ITK_LEGACY_REMOVE = ON

- ITK_FUTURE_LEGACY_REMOVE = ON

- Module_ITKMontage = ON

Build errors occur with references to older 'C' style enums. The following changes incorporate the new enum class: **FileModeType** and resolves such errors.

Co-Authored-By: Hans Johnson hans-johnson@uiowa.edu