### PR TITLE
ENH: add calculation of systematic translation bias to pair-wise test

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -307,7 +307,7 @@ function(GroundTruthTest2D tempDir inputFile) # other command-line parameters
       ${outDir}
       ${TESTING_OUTPUT_PATH}/itkMontageGT${tempDir}_
       ${TESTING_OUTPUT_PATH}/itkMontageGT${tempDir}Pairs_
-      0 1 1 1 0 0 0 0 1
+      0 1 1 1 1 0 0 0 1
     )
   SET_TESTS_PROPERTIES(itkMontageGroundTruthRun${tempDir}
     PROPERTIES DEPENDS itkMontageGroundTruthMake${tempDir})
@@ -473,7 +473,7 @@ itk_add_test(NAME itkMontageGroundTruthRun${tempDir}
     ${outDir}
     ${TESTING_OUTPUT_PATH}/itkMontageGT${tempDir}_
     ${TESTING_OUTPUT_PATH}/itkMontageGT${tempDir}Pairs_
-    0 1 1 1 0 0 0 0 1
+    0 1 1 1 1 0 0 0 1
   )
 SET_TESTS_PROPERTIES(itkMontageGroundTruthRun${tempDir}
   PROPERTIES DEPENDS itkMontageGroundTruthMake${tempDir})
@@ -565,7 +565,7 @@ if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/Input/Tiles/Image_10_10.tif)
       ${CMAKE_CURRENT_LIST_DIR}/Input/Tiles
       ${TESTING_OUTPUT_PATH}/itkMontageTiles
       ${TESTING_OUTPUT_PATH}/itkMontageTilesPairs
-      0 -1 1 1 0 0 0 0 1
+      0 -1 1 1 1 0 0 0 1
     )
     GroundTruthTest2D(Tiles ${CMAKE_CURRENT_LIST_DIR}/Input/Tiles/itkMontageTiles2_0.mha 10 10 10 10)
 endif()


### PR DESCRIPTION
Also enable pair-wise test for all ground truth tests.

Summary results (below) suggest presence of bias in sub-pixel peak estimation:
```text
PeakInterpolation 0 has average translation bias: -0.040 -0.028
PeakInterpolation 1 has average translation bias: -0.035 -0.025
PeakInterpolation 2 has average translation bias: -0.038 -0.027
Average translation error for padding method 2: 0.194
Test #52: itkMontageGroundTruthRun10-129 ..............***Failed    2.33 sec

PeakInterpolation 0 has average translation bias: -0.011 -0.017
PeakInterpolation 1 has average translation bias: -0.009 -0.014
PeakInterpolation 2 has average translation bias: -0.010 -0.016
Average translation error for padding method 2: 0.162
Test #54: itkMontageGroundTruthRunrun2 ................   Passed    1.58 sec

PeakInterpolation 0 has average translation bias: 0.021 -0.010
PeakInterpolation 1 has average translation bias: 0.019 -0.009
PeakInterpolation 2 has average translation bias: 0.020 -0.010
Average translation error for padding method 2: 0.172
Test #56: itkMontageGroundTruthRunMediumCarbonSteel ...***Failed    3.49 sec

PeakInterpolation 0 has average translation bias: 0.104 0.303 -0.040
PeakInterpolation 1 has average translation bias: 0.104 0.302 -0.041
PeakInterpolation 2 has average translation bias: 0.104 0.303 -0.041
Average translation error for padding method 2: 0.306
Test #70: itkMontageGroundTruthRunDzZ_T1 ..............***Failed   19.56 sec

PeakInterpolation 0 has average translation bias: 1.065 1.733
PeakInterpolation 1 has average translation bias: 1.066 1.734
PeakInterpolation 2 has average translation bias: 1.065 1.733
Average translation error for padding method 2: 1.811
Test #79: itkMontageGroundTruthRunTiles ...............***Failed   10.31 sec
```