### PR TITLE
ENH: update enums to match recent changes in ITK

### DIFF
--- a/examples/CompleteMontage.cxx
+++ b/examples/CompleteMontage.cxx
@@ -507,21 +507,21 @@ completeMontage(const itk::TileConfiguration<Dimension> & stageTiles,
                 const std::string &                       inputPath,
                 const std::string &                       outputPath,
                 const std::string &                       outFilename,
-                itk::ImageIOBase::IOPixelType             pixelType,
+                itk::CommonEnums::IOPixel                 pixelType,
                 bool                                      correctBias,
                 bool                                      denoise)
 {
   switch (pixelType)
   {
-    case itk::ImageIOBase::IOPixelType::SCALAR:
+    case itk::CommonEnums::IOPixel::SCALAR:
       completeMontage<Dimension, ComponentType, AccumulatePixelType>(
         stageTiles, inputPath, outputPath, outFilename, correctBias, denoise);
       break;
-    case itk::ImageIOBase::IOPixelType::RGB:
+    case itk::CommonEnums::IOPixel::RGB:
       completeMontage<Dimension, itk::RGBPixel<ComponentType>, itk::RGBPixel<AccumulatePixelType>>(
         stageTiles, inputPath, outputPath, outFilename, correctBias, denoise);
       break;
-    case itk::ImageIOBase::IOPixelType::RGBA:
+    case itk::CommonEnums::IOPixel::RGBA:
       completeMontage<Dimension, itk::RGBAPixel<ComponentType>, itk::RGBAPixel<AccumulatePixelType>>(
         stageTiles, inputPath, outputPath, outFilename, correctBias, denoise);
       break;
@@ -561,7 +561,7 @@ mainHelper(int argc, char * argv[], std::string inputPath)
 
   std::string               firstFilename = inputPath + stageTiles.Tiles[0].FileName;
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(firstFilename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(firstFilename.c_str(), itk::CommonEnums::IOFileMode::ReadMode);
   imageIO->SetFileName(firstFilename);
   imageIO->ReadImageInformation();
 
@@ -573,19 +573,19 @@ mainHelper(int argc, char * argv[], std::string inputPath)
                                                                  << numDimensions)
   }
 
-  const itk::ImageIOBase::IOPixelType     pixelType = imageIO->GetPixelType();
-  const itk::ImageIOBase::IOComponentType componentType = imageIO->GetComponentType();
+  const itk::CommonEnums::IOPixel     pixelType = imageIO->GetPixelType();
+  const itk::CommonEnums::IOComponent componentType = imageIO->GetComponentType();
   switch (componentType)
   {
-    case itk::ImageIOBase::IOComponentType::UCHAR:
+    case itk::CommonEnums::IOComponent::UCHAR:
       completeMontage<Dimension, unsigned char, unsigned int>(
         stageTiles, inputPath, outputPath, outFile, pixelType, doBiasCorrection, doDenoising);
       break;
-    case itk::ImageIOBase::IOComponentType::USHORT:
+    case itk::CommonEnums::IOComponent::USHORT:
       completeMontage<Dimension, unsigned short, double>(
         stageTiles, inputPath, outputPath, outFile, pixelType, doBiasCorrection, doDenoising);
       break;
-    case itk::ImageIOBase::IOComponentType::SHORT:
+    case itk::CommonEnums::IOComponent::SHORT:
       completeMontage<Dimension, short, double>(
         stageTiles, inputPath, outputPath, outFile, pixelType, doBiasCorrection, doDenoising);
       break;

--- a/examples/RefineMontage.cxx
+++ b/examples/RefineMontage.cxx
@@ -95,7 +95,7 @@ mainHelper(std::string inputPath, std::string inFile, std::string outFile)
 
   std::string               firstFilename = inputPath + stageTiles.Tiles[0].FileName;
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(firstFilename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(firstFilename.c_str(), itk::CommonEnums::IOFileMode::ReadMode);
   imageIO->SetFileName(firstFilename);
   imageIO->ReadImageInformation();
 
@@ -107,16 +107,16 @@ mainHelper(std::string inputPath, std::string inFile, std::string outFile)
                                                                  << numDimensions)
   }
 
-  const itk::ImageIOBase::IOComponentType componentType = imageIO->GetComponentType();
+  const itk::CommonEnums::IOComponent componentType = imageIO->GetComponentType();
   switch (componentType)
   {
-    case itk::ImageIOBase::IOComponentType::UCHAR:
+    case itk::CommonEnums::IOComponent::UCHAR:
       refineMontage<Dimension, unsigned char, unsigned int>(stageTiles, actualTiles, inputPath);
       break;
-    case itk::ImageIOBase::IOComponentType::USHORT:
+    case itk::CommonEnums::IOComponent::USHORT:
       refineMontage<Dimension, unsigned short, double>(stageTiles, actualTiles, inputPath);
       break;
-    case itk::ImageIOBase::IOComponentType::SHORT:
+    case itk::CommonEnums::IOComponent::SHORT:
       refineMontage<Dimension, short, double>(stageTiles, actualTiles, inputPath);
       break;
     default: // instantiating too many types leads to long compilation time and big executable

--- a/examples/ResampleMontage.cxx
+++ b/examples/ResampleMontage.cxx
@@ -88,18 +88,18 @@ void
 resampleMontage(const itk::TileConfiguration<Dimension> & actualTiles,
                 const std::string &                       inputPath,
                 const std::string &                       outFilename,
-                itk::ImageIOBase::IOPixelType             pixelType)
+                itk::CommonEnums::IOPixel                 pixelType)
 {
   switch (pixelType)
   {
-    case itk::ImageIOBase::IOPixelType::SCALAR:
+    case itk::CommonEnums::IOPixel::SCALAR:
       resampleMontage<Dimension, ComponentType, AccumulatePixelType>(actualTiles, inputPath, outFilename);
       break;
-    case itk::ImageIOBase::IOPixelType::RGB:
+    case itk::CommonEnums::IOPixel::RGB:
       resampleMontage<Dimension, itk::RGBPixel<ComponentType>, itk::RGBPixel<AccumulatePixelType>>(
         actualTiles, inputPath, outFilename);
       break;
-    case itk::ImageIOBase::IOPixelType::RGBA:
+    case itk::CommonEnums::IOPixel::RGBA:
       resampleMontage<Dimension, itk::RGBAPixel<ComponentType>, itk::RGBAPixel<AccumulatePixelType>>(
         actualTiles, inputPath, outFilename);
       break;
@@ -124,7 +124,7 @@ mainHelper(char * argv[])
 
   std::string               firstFilename = inputPath + actualTiles.Tiles[0].FileName;
   itk::ImageIOBase::Pointer imageIO =
-    itk::ImageIOFactory::CreateImageIO(firstFilename.c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    itk::ImageIOFactory::CreateImageIO(firstFilename.c_str(), itk::CommonEnums::IOFileMode::ReadMode);
   imageIO->SetFileName(firstFilename);
   imageIO->ReadImageInformation();
 
@@ -136,17 +136,17 @@ mainHelper(char * argv[])
                                                                  << numDimensions)
   }
 
-  const itk::ImageIOBase::IOPixelType     pixelType = imageIO->GetPixelType();
-  const itk::ImageIOBase::IOComponentType componentType = imageIO->GetComponentType();
+  const itk::CommonEnums::IOPixel     pixelType = imageIO->GetPixelType();
+  const itk::CommonEnums::IOComponent componentType = imageIO->GetComponentType();
   switch (componentType)
   {
-    case itk::ImageIOBase::IOComponentType::UCHAR:
+    case itk::CommonEnums::IOComponent::UCHAR:
       resampleMontage<Dimension, unsigned char, unsigned int>(actualTiles, inputPath, argv[2], pixelType);
       break;
-    case itk::ImageIOBase::IOComponentType::USHORT:
+    case itk::CommonEnums::IOComponent::USHORT:
       resampleMontage<Dimension, unsigned short, double>(actualTiles, inputPath, argv[2], pixelType);
       break;
-    case itk::ImageIOBase::IOComponentType::SHORT:
+    case itk::CommonEnums::IOComponent::SHORT:
       resampleMontage<Dimension, short, double>(actualTiles, inputPath, argv[2], pixelType);
       break;
     default: // instantiating too many types leads to long compilation time and big executable

--- a/test/itkInMemoryMontageTest2D.cxx
+++ b/test/itkInMemoryMontageTest2D.cxx
@@ -46,14 +46,14 @@ itkInMemoryMontageTest2D(int argc, char * argv[])
   stageTiles.Parse(inputPath + "TileConfiguration.registered.txt");
 
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-    (inputPath + stageTiles.Tiles[0].FileName).c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    (inputPath + stageTiles.Tiles[0].FileName).c_str(), itk::CommonEnums::IOFileMode::ReadMode);
   imageIO->SetFileName(inputPath + stageTiles.Tiles[0].FileName);
   imageIO->ReadImageInformation();
-  const itk::ImageIOBase::IOPixelType pixelType = imageIO->GetPixelType();
+  const itk::CommonEnums::IOPixel pixelType = imageIO->GetPixelType();
 
   std::string outFileName = std::string(argv[2]);
 
-  if (pixelType == itk::ImageIOBase::IOPixelType::RGB)
+  if (pixelType == itk::CommonEnums::IOPixel::RGB)
   {
     using TestTransformType = InMemoryMontageTest<itk::RGBPixel<unsigned char>, itk::RGBPixel<unsigned int>>;
 

--- a/test/itkMontagePCMTestFiles.cxx
+++ b/test/itkMontagePCMTestFiles.cxx
@@ -158,10 +158,10 @@ itkMontagePCMTestFiles(int argc, char * argv[])
   try
   {
     itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(argv[1], itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(argv[1], itk::CommonEnums::IOFileMode::ReadMode);
     imageIO->SetFileName(argv[1]);
     imageIO->ReadImageInformation();
-    // const itk::ImageIOBase::IOComponentType pixelType = imageIO->GetComponentType();
+    // const itk::CommonEnums::IOComponent pixelType = imageIO->GetComponentType();
     const size_t numDimensions = imageIO->GetNumberOfDimensions();
     if (numDimensions <= 2)
     {

--- a/test/itkMontageTest.cxx
+++ b/test/itkMontageTest.cxx
@@ -111,18 +111,18 @@ itkMontageTestHelper(int argc, char * argv[], const std::string & inputPath)
   actualTiles.Parse(inputPath + "TileConfiguration.registered.txt");
 
   itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO(
-    (inputPath + stageTiles.Tiles[0].FileName).c_str(), itk::ImageIOFactory::FileModeEnum::ReadMode);
+    (inputPath + stageTiles.Tiles[0].FileName).c_str(), itk::CommonEnums::IOFileMode::ReadMode);
   imageIO->SetFileName(inputPath + stageTiles.Tiles[0].FileName);
   imageIO->ReadImageInformation();
-  const itk::ImageIOBase::IOPixelType     pixelType = imageIO->GetPixelType();
-  const itk::ImageIOBase::IOComponentType cType = imageIO->GetComponentType();
+  const itk::CommonEnums::IOPixel     pixelType = imageIO->GetPixelType();
+  const itk::CommonEnums::IOComponent cType = imageIO->GetComponentType();
 
-  if (pixelType == itk::ImageIOBase::IOPixelType::RGB)
+  if (pixelType == itk::CommonEnums::IOPixel::RGB)
   {
     return itkMontageTestHelper2<itk::RGBPixel<unsigned char>, itk::RGBPixel<unsigned int>>(
       argc, argv, inputPath, stageTiles, actualTiles);
   }
-  else if (cType == itk::ImageIOBase::IOComponentType::SHORT)
+  else if (cType == itk::CommonEnums::IOComponent::SHORT)
   {
     return itkMontageTestHelper2<short, double>(argc, argv, inputPath, stageTiles, actualTiles);
   }

--- a/test/itkMontageTruthCreator.cxx
+++ b/test/itkMontageTruthCreator.cxx
@@ -173,9 +173,9 @@ CreateGroundTruth(int argc, char * argv[], unsigned dimension)
 
 template <typename ComponentType>
 int
-CreateGroundTruth(int argc, char * argv[], unsigned dimension, itk::ImageIOBase::IOPixelType pixelType)
+CreateGroundTruth(int argc, char * argv[], unsigned dimension, itk::CommonEnums::IOPixel pixelType)
 {
-  if (pixelType == itk::ImageIOBase::IOPixelType::RGB) // possibly add RGBA
+  if (pixelType == itk::CommonEnums::IOPixel::RGB) // possibly add RGBA
   {
     return CreateGroundTruth<itk::RGBPixel<ComponentType>>(argc, argv, dimension);
   }
@@ -199,21 +199,21 @@ itkMontageTruthCreator(int argc, char * argv[])
   try
   {
     itk::ImageIOBase::Pointer imageIO =
-      itk::ImageIOFactory::CreateImageIO(argv[1], itk::ImageIOFactory::FileModeEnum::ReadMode);
+      itk::ImageIOFactory::CreateImageIO(argv[1], itk::CommonEnums::IOFileMode::ReadMode);
     imageIO->SetFileName(argv[1]);
     imageIO->ReadImageInformation();
-    unsigned                                dim = imageIO->GetNumberOfDimensions();
-    const itk::ImageIOBase::IOComponentType cType = imageIO->GetComponentType();
+    unsigned                            dim = imageIO->GetNumberOfDimensions();
+    const itk::CommonEnums::IOComponent cType = imageIO->GetComponentType();
 
-    if (cType == itk::ImageIOBase::IOComponentType::UCHAR)
+    if (cType == itk::CommonEnums::IOComponent::UCHAR)
     {
       return CreateGroundTruth<unsigned char>(argc, argv, dim, imageIO->GetPixelType());
     }
-    else if (cType == itk::ImageIOBase::IOComponentType::USHORT)
+    else if (cType == itk::CommonEnums::IOComponent::USHORT)
     {
       return CreateGroundTruth<unsigned short>(argc, argv, dim, imageIO->GetPixelType());
     }
-    else if (cType == itk::ImageIOBase::IOComponentType::SHORT)
+    else if (cType == itk::CommonEnums::IOComponent::SHORT)
     {
       return CreateGroundTruth<short>(argc, argv, dim, imageIO->GetPixelType());
     }


### PR DESCRIPTION
These changes are required to build with legacy off. Further changes are required with respect to enum `ostream operator <<`, which are being taken care of in #146.