### PR TITLE
Fix compiler error due to use of non enum macro.

### DIFF
--- a/include/itkTileMontage.h
+++ b/include/itkTileMontage.h
@@ -162,7 +162,7 @@ public:
   itkGetConstMacro(PaddingMethod, PhaseCorrelationImageRegistrationMethodEnums::PaddingMethod);
 
   /** Set/Get the peak interpolation method. */
-  itkSetMacro(PeakInterpolationMethod, typename PCMOptimizerType::PeakInterpolationMethodEnum);
+  itkSetEnumMacro(PeakInterpolationMethod, typename PCMOptimizerType::PeakInterpolationMethodEnum);
   itkGetConstMacro(PeakInterpolationMethod, typename PCMOptimizerType::PeakInterpolationMethodEnum);
 
   /** Get/Set size of the image mosaic. */


### PR DESCRIPTION
This is causing compile errors when used in our own projects (DREAM.3D and ITKImageProcessingPlugin)


Signed-off-by: Michael Jackson <mike.jackson@bluequartz.net>