### PR TITLE
ENH: add a concept check to make sure we are not instantiated with bool

### DIFF
--- a/include/itkPhaseCorrelationOptimizer.h
+++ b/include/itkPhaseCorrelationOptimizer.h
@@ -234,6 +234,10 @@ public:
   itkGetConstMacro(PhaseInterpolated, unsigned int);
   itkSetMacro(PhaseInterpolated, unsigned int);
 
+#ifdef ITK_USE_CONCEPT_CHECKING
+  static_assert(!std::is_same<TRealPixel, bool>::value, "bool is not supported as RealPixelType");
+#endif
+
 protected:
   PhaseCorrelationOptimizer();
   ~PhaseCorrelationOptimizer() override = default;


### PR DESCRIPTION
This gives a much more humane error message.