### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkNMinimaMaximaImageCalculator.h
+++ b/include/itkNMinimaMaximaImageCalculator.h
@@ -41,7 +41,7 @@ template <typename TInputImage>
 class ITK_TEMPLATE_EXPORT NMinimaMaximaImageCalculator : public Object
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(NMinimaMaximaImageCalculator);
+  ITK_DISALLOW_COPY_AND_MOVE(NMinimaMaximaImageCalculator);
 
   /** Standard class type aliases. */
   using Self = NMinimaMaximaImageCalculator;

--- a/include/itkPhaseCorrelationImageRegistrationMethod.h
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.h
@@ -134,7 +134,7 @@ template <
 class ITK_TEMPLATE_EXPORT PhaseCorrelationImageRegistrationMethod : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseCorrelationImageRegistrationMethod);
+  ITK_DISALLOW_COPY_AND_MOVE(PhaseCorrelationImageRegistrationMethod);
 
   /** Standard class type aliases. */
   using Self = PhaseCorrelationImageRegistrationMethod;

--- a/include/itkPhaseCorrelationOperator.h
+++ b/include/itkPhaseCorrelationOperator.h
@@ -44,7 +44,7 @@ class ITK_TEMPLATE_EXPORT PhaseCorrelationOperator
                               Image<std::complex<TRealPixel>, VImageDimension>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseCorrelationOperator);
+  ITK_DISALLOW_COPY_AND_MOVE(PhaseCorrelationOperator);
 
   using Self = PhaseCorrelationOperator;
   using Superclass = ImageToImageFilter<Image<std::complex<TRealPixel>, VImageDimension>,

--- a/include/itkPhaseCorrelationOptimizer.h
+++ b/include/itkPhaseCorrelationOptimizer.h
@@ -119,7 +119,7 @@ template <typename TRealPixel, unsigned int VImageDimension>
 class ITK_TEMPLATE_EXPORT PhaseCorrelationOptimizer : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(PhaseCorrelationOptimizer);
+  ITK_DISALLOW_COPY_AND_MOVE(PhaseCorrelationOptimizer);
 
   using Self = PhaseCorrelationOptimizer;
   using Superclass = ProcessObject;

--- a/include/itkTileMergeImageFilter.h
+++ b/include/itkTileMergeImageFilter.h
@@ -52,7 +52,7 @@ class ITK_TEMPLATE_EXPORT TileMergeImageFilter
       typename TInterpolator::CoordRepType>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TileMergeImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(TileMergeImageFilter);
 
   /** We define superclass with scalar pixel type, to enable compiling even when RGB pixel is supplied. */
   using Superclass =

--- a/include/itkTileMontage.h
+++ b/include/itkTileMontage.h
@@ -45,7 +45,7 @@ template <typename TImageType,
 class ITK_TEMPLATE_EXPORT TileMontage : public ProcessObject
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(TileMontage);
+  ITK_DISALLOW_COPY_AND_MOVE(TileMontage);
 
   /** Standard class type aliases. */
   using Self = TileMontage;

--- a/test/itkInMemoryMontageTestHelper.hxx
+++ b/test/itkInMemoryMontageTestHelper.hxx
@@ -41,7 +41,7 @@ public:
   InMemoryMontageTest() = default;
   ~InMemoryMontageTest() override = default;
 
-  ITK_DISALLOW_COPY_AND_ASSIGN(InMemoryMontageTest);
+  ITK_DISALLOW_COPY_AND_MOVE(InMemoryMontageTest);
 
   /** Standard class type aliases. */
   using Self = InMemoryMontageTest;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.