### PR TITLE
COMP: use built-in ReadImage and WriteImage convenience functions

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "v5.1.2"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "v5.1.2"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.1.1"
+            itk-git-tag: "v5.1.2"
             cmake-build-type: "MinSizeRel"
 
     steps:
@@ -38,6 +38,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install ninja
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: Download ITK
       run: |
@@ -133,7 +136,7 @@ jobs:
       matrix:
         python-version: [36, 37, 38, 39]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.1.2"
 
     steps:
     - uses: actions/checkout@v2
@@ -169,10 +172,17 @@ jobs:
       max-parallel: 2
       matrix:
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.1.2"
 
     steps:
     - uses: actions/checkout@v2
+
+    - name: 'Specific XCode version'
+      run: |
+        sudo xcode-select -s "/Applications/Xcode_11.7.app"
+
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
 
     - name: 'Fetch build script'
       run: |
@@ -198,9 +208,12 @@ jobs:
       matrix:
         python-version-minor: [6, 7, 8, 9]
         include:
-          - itk-python-git-tag: "v5.1.1.post1"
+          - itk-python-git-tag: "v5.1.2"
 
     steps:
+    - name: Get specific version of CMake, Ninja
+      uses: lukka/get-cmake@v3.18.3
+
     - uses: actions/checkout@v2
       with:
         path: "im"

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -13,17 +13,17 @@ jobs:
           - os: ubuntu-18.04
             c-compiler: "gcc"
             cxx-compiler: "g++"
-            itk-git-tag: "v5.1.2"
+            itk-git-tag: "master"
             cmake-build-type: "MinSizeRel"
           - os: windows-2019
             c-compiler: "cl.exe"
             cxx-compiler: "cl.exe"
-            itk-git-tag: "v5.1.2"
+            itk-git-tag: "master"
             cmake-build-type: "Release"
           - os: macos-10.15
             c-compiler: "clang"
             cxx-compiler: "clang++"
-            itk-git-tag: "v5.1.2"
+            itk-git-tag: "master"
             cmake-build-type: "MinSizeRel"
 
     steps:

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -8,7 +8,7 @@ set(ExampleSpecificComponents
   )
 
 if(NOT ITK_SOURCE_DIR)
-  find_package(ITK REQUIRED COMPONENTS Montage ITKImageIO ITKTransformIO ITKTestKernel ${ExampleSpecificComponents})
+  find_package(ITK 5.2 REQUIRED COMPONENTS Montage ITKImageIO ITKTransformIO ITKTestKernel ${ExampleSpecificComponents})
 else()
   # when being built as part of ITK, ITKImageIO and ITKTransformIO
   # lists of modules are not yet ready, causing a configure error

--- a/examples/CompleteMontage.cxx
+++ b/examples/CompleteMontage.cxx
@@ -33,29 +33,6 @@
 #include "itkBilateralImageFilter.h"
 #include "itkComposeImageFilter.h"
 
-template <typename TImage>
-typename TImage::Pointer
-ReadImage(const char * filename)
-{
-  using ReaderType = itk::ImageFileReader<TImage>;
-  typename ReaderType::Pointer reader = ReaderType::New();
-  reader->SetFileName(filename);
-  reader->Update();
-  return reader->GetOutput();
-}
-
-template <typename TImage>
-void
-WriteImage(const TImage * out, const char * filename, bool compress)
-{
-  using WriterType = itk::ImageFileWriter<TImage>;
-  typename WriterType::Pointer w = WriterType::New();
-  w->SetInput(out);
-  w->SetFileName(filename);
-  w->SetUseCompression(compress);
-  w->Update();
-}
-
 template <typename TransformType>
 void
 WriteTransform(const TransformType * transform, std::string filename)
@@ -397,7 +374,7 @@ completeMontage(const itk::TileConfiguration<Dimension> & stageTiles,
   for (size_t t = 0; t < stageTiles.LinearSize(); t++)
   {
     std::string                         filename = inputPath + stageTiles.Tiles[t].FileName;
-    typename OriginalImageType::Pointer image = ReadImage<OriginalImageType>(filename.c_str());
+    typename OriginalImageType::Pointer image = itk::ReadImage<OriginalImageType>(filename.c_str());
     typename TileConfig::PointType      origin = stageTiles.Tiles[t].Position;
     std::cout << 'R' << std::flush;
 
@@ -421,7 +398,7 @@ completeMontage(const itk::TileConfiguration<Dimension> & stageTiles,
       avgSpacing = std::pow(avgSpacing, 1.0 / Dimension);
 
       image = denoiseImage<PixelType, Dimension>(image, avgSpacing);
-      WriteImage(image.GetPointer(), (outputPath + stageTiles.Tiles[t].FileName + "-bil.nrrd").c_str(), true);
+      itk::WriteImage(image.GetPointer(), (outputPath + stageTiles.Tiles[t].FileName + "-bil.nrrd").c_str(), true);
       std::cout << 'D' << std::flush;
     }
 
@@ -439,7 +416,7 @@ completeMontage(const itk::TileConfiguration<Dimension> & stageTiles,
       std::string baseFileName = itksys::SystemTools::GetFilenameWithoutLastExtension(stageTiles.Tiles[t].FileName);
       std::string flatFileName = baseFileName + "-flat" + fileNameExt;
       actualTiles.Tiles[t].FileName = flatFileName;
-      WriteImage(image.GetPointer(), (outputPath + flatFileName).c_str(), true);
+      itk::WriteImage(image.GetPointer(), (outputPath + flatFileName).c_str(), true);
     }
     oImages[t] = image;
 
@@ -495,7 +472,7 @@ completeMontage(const itk::TileConfiguration<Dimension> & stageTiles,
   std::cout << std::endl;
 
   std::cout << "Writing the final image...";
-  WriteImage(resampleF->GetOutput(), outFilename.c_str(), true);
+  itk::WriteImage(resampleF->GetOutput(), outFilename.c_str(), true);
   std::cout << "Done!" << std::endl;
 }
 


### PR DESCRIPTION
Fixes compile errors of style:
```
  M:\Dashboard\ITK\Modules\Remote\Montage\examples\CompleteMontage.cxx(424): error C2666: 'WriteImage': 2 overloads have similar conversions [M:\Dashboard\ITK-build\Modules\Remote\Montage\examples\CompleteMontage.vcxproj]

  M:\Dashboard\ITK\Modules\Remote\Montage\examples\CompleteMontage.cxx(49): note: could be 'void WriteImage<itk::Image<ScalarPixelType,2>>(const TImage *,const char *,bool)'
          with
          [
              TImage=itk::Image<ScalarPixelType,2>
          ]
  m:\dashboard\itk\modules\io\imagebase\include\itkImageFileWriter.h(247): note: or       'void itk::WriteImage<itk::Image<ScalarPixelType,2>*>(TImagePointer &&,const std::string &,bool)' [found using argument-dependent lookup]
          with
          [
              TImagePointer=itk::Image<ScalarPixelType,2> *
          ]
```