### PR TITLE
STYLE: Force semi-colon at end of macros

### DIFF
--- a/examples/CompleteMontage.cxx
+++ b/examples/CompleteMontage.cxx
@@ -120,9 +120,10 @@ public:
   using Self = CommandIterationUpdate;
   using Superclass = itk::Command;
   using Pointer = itk::SmartPointer<Self>;
-  itkNewMacro(Self)
+  itkNewMacro(Self);
 
-    protected : CommandIterationUpdate() = default;
+protected:
+  CommandIterationUpdate() = default;
 
 public:
   void
@@ -503,7 +504,8 @@ completeMontage(const itk::TileConfiguration<Dimension> & stageTiles,
         stageTiles, inputPath, outputPath, outFilename, correctBias, denoise);
       break;
     default:
-      itkGenericExceptionMacro("Only sclar, RGB and RGBA images are supported!") break;
+      itkGenericExceptionMacro("Only sclar, RGB and RGBA images are supported!");
+      break;
   }
 }
 
@@ -547,7 +549,7 @@ mainHelper(int argc, char * argv[], std::string inputPath)
   {
     itkGenericExceptionMacro("Tile configuration has dimension " << Dimension << ", but image\n"
                                                                  << firstFilename << "\nhas dimension "
-                                                                 << numDimensions)
+                                                                 << numDimensions);
   }
 
   const itk::IOPixelEnum     pixelType = imageIO->GetPixelType();
@@ -569,7 +571,8 @@ mainHelper(int argc, char * argv[], std::string inputPath)
     default: // instantiating too many types leads to long compilation time and big executable
       itkGenericExceptionMacro(
         "Only unsigned char, unsigned short and short are supported as pixel component types! Trying to montage "
-        << itk::ImageIOBase::GetComponentTypeAsString(componentType)) break;
+        << itk::ImageIOBase::GetComponentTypeAsString(componentType));
+      break;
   }
 
   return EXIT_SUCCESS;

--- a/examples/RefineMontage.cxx
+++ b/examples/RefineMontage.cxx
@@ -104,7 +104,7 @@ mainHelper(std::string inputPath, std::string inFile, std::string outFile)
   {
     itkGenericExceptionMacro("Tile configuration has dimension " << Dimension << ", but image\n"
                                                                  << firstFilename << "\nhas dimension "
-                                                                 << numDimensions)
+                                                                 << numDimensions);
   }
 
   const itk::IOComponentEnum componentType = imageIO->GetComponentType();
@@ -122,7 +122,7 @@ mainHelper(std::string inputPath, std::string inFile, std::string outFile)
     default: // instantiating too many types leads to long compilation time and big executable
       itkGenericExceptionMacro(
         "Only unsigned char, unsigned short and short are supported as pixel component types! Trying to montage "
-        << itk::ImageIOBase::GetComponentTypeAsString(componentType))
+        << itk::ImageIOBase::GetComponentTypeAsString(componentType));
   }
 
   actualTiles.Write(outFile);

--- a/test/itkInMemoryMontageTestHelper.hxx
+++ b/test/itkInMemoryMontageTestHelper.hxx
@@ -49,18 +49,19 @@ public:
   using ConstPointer = itk::SmartPointer<const Self>;
 
   /** New macro for creation of through a Smart Pointer. */
-  itkNewMacro(Self)
+  itkNewMacro(Self);
 
-    enum class TestVariation : unsigned int {
-      UOrigin_USpacing_UTransform = 0,
-      UOrigin_DSpacing_UTransform,
-      UOrigin_USpacing_DTransform,
-      UOrigin_DSpacing_DTransform,
-      DOrigin_USpacing_UTransform,
-      DOrigin_DSpacing_UTransform,
-      DOrigin_USpacing_DTransform,
-      DOrigin_DSpacing_DTransform,
-    };
+  enum class TestVariation : unsigned int
+  {
+    UOrigin_USpacing_UTransform = 0,
+    UOrigin_DSpacing_UTransform,
+    UOrigin_USpacing_DTransform,
+    UOrigin_DSpacing_DTransform,
+    DOrigin_USpacing_UTransform,
+    DOrigin_DSpacing_UTransform,
+    DOrigin_USpacing_DTransform,
+    DOrigin_DSpacing_DTransform,
+  };
 
   /* -----------------------------------------------------------------------------------------------
    * This method tests stitching images with different combinations of origins, spacings, and


### PR DESCRIPTION
Make clang-format more consistent by enforcing semi-colons
at the end of macros.