### PR TITLE
STYLE: 2nd attempt to force semi-colon at end of macros

### DIFF
--- a/examples/ResampleMontage.cxx
+++ b/examples/ResampleMontage.cxx
@@ -105,7 +105,8 @@ resampleMontage(const itk::TileConfiguration<Dimension> & actualTiles,
       break;
     default:
       itkGenericExceptionMacro("Only sclar, RGB and RGBA images are supported! Actual pixel type: "
-                               << itk::ImageIOBase::GetPixelTypeAsString(pixelType)) break;
+                               << itk::ImageIOBase::GetPixelTypeAsString(pixelType));
+      break;
   }
 }
 
@@ -133,7 +134,7 @@ mainHelper(char * argv[])
   {
     itkGenericExceptionMacro("Tile configuration has dimension " << Dimension << ", but image\n"
                                                                  << firstFilename << "\nhas dimension "
-                                                                 << numDimensions)
+                                                                 << numDimensions);
   }
 
   const itk::IOPixelEnum     pixelType = imageIO->GetPixelType();
@@ -152,7 +153,8 @@ mainHelper(char * argv[])
     default: // instantiating too many types leads to long compilation time and big executable
       itkGenericExceptionMacro(
         "Only unsigned char, unsigned short and short are supported as pixel component types! Trying to montage "
-        << itk::ImageIOBase::GetComponentTypeAsString(componentType)) break;
+        << itk::ImageIOBase::GetComponentTypeAsString(componentType));
+      break;
   }
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
Make clang-format more consistent by enforcing semi-colons
at the end of macros.