### PR TITLE
COMP: Fix initializer list lifetime warning

### DIFF
--- a/test/itkMontageTestHelper.hxx
+++ b/test/itkMontageTestHelper.hxx
@@ -245,7 +245,10 @@ montageTest(const itk::TileConfiguration<Dimension> & stageTiles,
     if (peakMethodToUse >= 0)
     {
       auto peakMethodNumber = static_cast<PeakMethodUnderlying>(peakMethodToUse);
-      interpolationMethods = { static_cast<PeakInterpolationType>(peakMethodNumber) };
+      std::initializer_list<itk::PhaseCorrelationOptimizerEnums::PeakInterpolationMethod> interpMethods = {
+        static_cast<PeakInterpolationType>(peakMethodNumber)
+      };
+      interpolationMethods = interpMethods;
     }
     for (auto peakMethod : interpolationMethods)
     {


### PR DESCRIPTION
Fix initializer list lifetime warning.

Fixes:
```
Modules/Remote/Montage/test/itkMontageTestHelper.hxx:248:28: warning:
assignment from temporary initializer_list does not extend the lifetime of the underlying array [-Winit-list-lifetime]
248 |       interpolationMethods = { static_cast<PeakInterpolationType>(peakMethodNumber) };
    |       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

raised at:
https://open.cdash.org/viewBuildError.php?type=1&buildid=7491724