### PR TITLE
COMP: avoiding deprecated itkGetStaticConstMacro

### DIFF
--- a/include/itkPhaseCorrelationImageRegistrationMethod.h
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.h
@@ -173,7 +173,7 @@ public:
   using RealImageType = Image<InternalPixelType, ImageDimension>;
 
   /** Type of the image, that is passed between the internal components. */
-  using ComplexConjugateImageType = Image<std::complex<InternalPixelType>, itkGetStaticConstMacro(ImageDimension)>;
+  using ComplexConjugateImageType = Image<std::complex<InternalPixelType>, Self::ImageDimension>;
 
   /**  Type of the Operator */
   using OperatorType = PhaseCorrelationOperator<InternalPixelType, ImageDimension>;


### PR DESCRIPTION
With legacy disabled, the following error is generated on GCC 9.3:

In file included from /home/dzenan/ITKMontage/src/itkPhaseCorrelationImageRegistrationMethod.cxx:18:
/home/dzenan/ITKMontage/include/itkPhaseCorrelationImageRegistrationMethod.h:176:114: error: ‘"Replace itkGetStaticConstMacro(name) with `Self::name`"’ is not a valid template argument for type ‘unsigned int’ because string literals can never be used in this context
  176 |   using ComplexConjugateImageType = Image<std::complex<InternalPixelType>, itkGetStaticConstMacro(ImageDimension)>;
      |                                                                                                                  ^
/home/dzenan/ITKMontage/include/itkPhaseCorrelationImageRegistrationMethod.h:349:11: error: ‘ComplexConjugateImageType’ does not name a type; did you mean ‘ComplexImageType’?
  349 |   virtual ComplexConjugateImageType *
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~
      |           ComplexImageType