### PR TITLE
Default to C++14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CMAKE_CXX_STANDARD EQUAL "98" )
 endif()
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 11) # Supported values are ``11``, ``14``, and ``17``.
+  set(CMAKE_CXX_STANDARD 14) # Supported values are ``11``, ``14``, and ``17``.
 endif()
 if(NOT CMAKE_CXX_STANDARD_REQUIRED)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Updates ITKMontage to match the ITK default C++14 standard (see [https://github.com/InsightSoftwareConsortium/ITK/blob/master/CMake/ITKInitializeCXXStandard.cmake#L3](https://github.com/InsightSoftwareConsortium/ITK/blob/master/CMake/ITKInitializeCXXStandard.cmake#L3)). 

Attempting to build ITKMontage with the C++11 standard against an ITK instance built against the C++14 default standard yields a warning and subsequent errors:
```sh
ITK-build-dev/Modules/Core/Common/itkConfigure.h:56:6: warning: #warning "WARNING:  The current project is configured to use a C++ standard version older than the C++ standard used for this build of ITK" [-Wcpp]
   56 |     #warning "WARNING:  The current project is configured to use a C++ standard version older than the C++ standard used for this build of ITK"
      |      ^~~~~~~
```