### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkNMinimaMaximaImageCalculator.hxx
+++ b/include/itkNMinimaMaximaImageCalculator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkNMinimaMaximaImageCalculator_hxx
 #define itkNMinimaMaximaImageCalculator_hxx
 
-#include "itkNMinimaMaximaImageCalculator.h"
 
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkMultiThreaderBase.h"

--- a/include/itkPhaseCorrelationImageRegistrationMethod.hxx
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.hxx
@@ -18,7 +18,6 @@
 #ifndef itkPhaseCorrelationImageRegistrationMethod_hxx
 #define itkPhaseCorrelationImageRegistrationMethod_hxx
 
-#include "itkPhaseCorrelationImageRegistrationMethod.h"
 
 #include "itkMath.h"
 #include "itkNumericTraits.h"

--- a/include/itkPhaseCorrelationOperator.hxx
+++ b/include/itkPhaseCorrelationOperator.hxx
@@ -18,7 +18,6 @@
 #ifndef itkPhaseCorrelationOperator_hxx
 #define itkPhaseCorrelationOperator_hxx
 
-#include "itkPhaseCorrelationOperator.h"
 
 #include "itkImageScanlineIterator.h"
 #include "itkMetaDataObject.h"

--- a/include/itkPhaseCorrelationOptimizer.hxx
+++ b/include/itkPhaseCorrelationOptimizer.hxx
@@ -412,7 +412,7 @@ PhaseCorrelationOptimizer<TRealPixelType, VImageDimension>::ComputeOffset()
         SizeValueType dist = 0;
         for (unsigned d = 0; d < ImageDimension; d++)
         {
-          SizeValueType d1 = std::abs(m_MaxIndices[i][d] - m_MaxIndices[k][d]);
+          SizeValueType d1 = itk::Math::abs(m_MaxIndices[i][d] - m_MaxIndices[k][d]);
           if (d1 > size[d] / 2) // wrap around
           {
             d1 = size[d] - d1;
@@ -484,7 +484,7 @@ PhaseCorrelationOptimizer<TRealPixelType, VImageDimension>::ComputeOffset()
         (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - oIndex[i]);
       const OffsetScalarType mirrorOffset =
         (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - adjustedSize[i]);
-      if (std::abs(directOffset) <= std::abs(mirrorOffset))
+      if (itk::Math::abs(directOffset) <= itk::Math::abs(mirrorOffset))
       {
         offset[i] = directOffset;
       }
@@ -562,7 +562,7 @@ PhaseCorrelationOptimizer<TRealPixelType, VImageDimension>::ComputeOffset()
           (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - oIndex[i]);
         const OffsetScalarType mirrorOffset =
           (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - adjustedSize[i]);
-        if (std::abs(directOffset) <= std::abs(mirrorOffset))
+        if (itk::Math::abs(directOffset) <= itk::Math::abs(mirrorOffset))
         {
           this->m_Offsets[offsetIndex][i] = directOffset;
         }
@@ -625,7 +625,7 @@ PhaseCorrelationOptimizer<TRealPixelType, VImageDimension>::ComputeOffset()
             (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - oIndex[i]);
           const OffsetScalarType mirrorOffset =
             (movingOrigin[i] - fixedOrigin[i]) - 1 * spacing[i] * (maxIndex[i] - adjustedSize[i]);
-          if (std::abs(directOffset) <= std::abs(mirrorOffset))
+          if (itk::Math::abs(directOffset) <= itk::Math::abs(mirrorOffset))
           {
             this->m_Offsets[peak][i] = directOffset;
           }

--- a/include/itkPhaseCorrelationOptimizer.hxx
+++ b/include/itkPhaseCorrelationOptimizer.hxx
@@ -18,7 +18,6 @@
 #ifndef itkPhaseCorrelationOptimizer_hxx
 #define itkPhaseCorrelationOptimizer_hxx
 
-#include "itkPhaseCorrelationOptimizer.h"
 
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIteratorWithIndex.h"

--- a/include/itkTileMergeImageFilter.hxx
+++ b/include/itkTileMergeImageFilter.hxx
@@ -484,7 +484,7 @@ TileMergeImageFilter<TImageType, TPixelAccumulateType, TInterpolator>::ResampleS
       for (unsigned d = 0; d < ImageDimension; d++)
       {
         ContinuousValueType translation = (oOrigin[d] - iOrigin[d]) / spacing[d] + continuousIndexDifferences[t][d];
-        ContinuousValueType absDiff = std::abs(translation - std::round(translation));
+        ContinuousValueType absDiff = itk::Math::abs(translation - std::round(translation));
         if (absDiff > eps)
         {
           interpolate = true;

--- a/include/itkTileMergeImageFilter.hxx
+++ b/include/itkTileMergeImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkTileMergeImageFilter_hxx
 #define itkTileMergeImageFilter_hxx
 
-#include "itkTileMergeImageFilter.h"
 
 #include "itkMultiThreaderBase.h"
 

--- a/include/itkTileMontage.hxx
+++ b/include/itkTileMontage.hxx
@@ -19,7 +19,6 @@
 #ifndef itkTileMontage_hxx
 #define itkTileMontage_hxx
 
-#include "itkTileMontage.h"
 
 #include "itkMultiThreaderBase.h"
 #include "itkNumericTraits.h"

--- a/include/itkTileMontage.hxx
+++ b/include/itkTileMontage.hxx
@@ -492,7 +492,7 @@ TileMontage<TImageType, TCoordinate>::OptimizeTiles()
       for (unsigned d = 0; d < ImageDimension; d++)
       {
         TCoordinate trOverDev = translations(i, d) / stdDev0(d);
-        outlierScore[i] += std::abs(trOverDev);
+        outlierScore[i] += itk::Math::abs(trOverDev);
       }
       if (outlierScore[i] > m_RelativeThreshold) // more than this many standard deviations
       {

--- a/test/itkMontagePCMTestSynthetic.cxx
+++ b/test/itkMontagePCMTestSynthetic.cxx
@@ -271,7 +271,7 @@ PhaseCorrelationRegistration(int argc, char * argv[])
           // All other parameters must be 0
           for (unsigned int i = numberOfParameters; i < VDimension; i++)
           {
-            if ((std::abs(finalParameters[i]) > tolerance) || (std::abs(transformParameters[i]) > tolerance))
+            if ((itk::Math::abs(finalParameters[i]) > tolerance) || (itk::Math::abs(transformParameters[i]) > tolerance))
             {
               std::cout << "Tolerance exceeded at component " << i << std::endl;
               pass = false;

--- a/test/itkMontageTestHelper.hxx
+++ b/test/itkMontageTestHelper.hxx
@@ -339,8 +339,8 @@ montageTest(const itk::TileConfiguration<Dimension> & stageTiles,
         {
           registrationErrors << '\t' << (tr[d] - ta[d]);
           std::cout << "  " << std::setw(8) << std::setprecision(3) << (tr[d] - ta[d]);
-          singleError += std::abs(tr[d] - ta[d]);
-          alternativeError += std::abs(avgPos[t][d] - ta[d]);
+          singleError += itk::Math::abs(tr[d] - ta[d]);
+          alternativeError += itk::Math::abs(avgPos[t][d] - ta[d]);
         }
 
         if (alternativeError >= 5.0 && alternativeError < singleError)

--- a/test/itkPairwiseTestHelper.hxx
+++ b/test/itkPairwiseTestHelper.hxx
@@ -154,7 +154,7 @@ calculateError(const itk::TileConfiguration<Dimension> &                        
     {
       out << '\t' << (tr[d] - ta[d]);
       std::cout << "  " << std::setw(8) << std::setprecision(8) << (tr[d] - ta[d]);
-      translationError += std::abs(tr[d] - ta[d]);
+      translationError += itk::Math::abs(tr[d] - ta[d]);
     }
     std::cout << std::endl;
     out << std::endl;


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

