### PR TITLE
COMP: Update type correctness of point and vector math

### DIFF
--- a/include/itkPhaseCorrelationImageRegistrationMethod.hxx
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.hxx
@@ -248,7 +248,8 @@ PhaseCorrelationImageRegistrationMethod<TFixedImage, TMovingImage, TInternalPixe
     typename MovingImageType::SpacingType spacing = m_MovingImage->GetSpacing();
     typename MovingImageType::IndexType   shiftIndex, fIndex;
     typename MovingImageType::IndexType   mIndex = mRegion.GetIndex();
-    typename MovingImageType::PointType   originShift = m_MovingImage->GetOrigin() - m_FixedImage->GetOrigin();
+
+    auto originShift = m_MovingImage->GetOrigin() - m_FixedImage->GetOrigin();
     for (unsigned int d = 0; d < ImageDimension; ++d)
     {
       shiftIndex[d] = std::round(originShift[d] / spacing[d]);

--- a/test/itkMontageTestHelper.hxx
+++ b/test/itkMontageTestHelper.hxx
@@ -130,7 +130,7 @@ montageTest(const itk::TileConfiguration<Dimension> & stageTiles,
     origin1[d] = stageTiles.AxisSizes[d] > 1 ? 1 : 0; // support montages of size 1 along a dimension
   }
   size_t    origin1linear = stageTiles.nDIndexToLinearIndex(origin1);
-  PointType originAdjustment = stageTiles.Tiles[origin1linear].Position - stageTiles.Tiles[0].Position;
+  PointType originAdjustment = PointType(stageTiles.Tiles[origin1linear].Position - stageTiles.Tiles[0].Position);
 
   using PeakInterpolationType = itk::PhaseCorrelationOptimizerEnums::PeakInterpolationMethod;
   using PeakMethodUnderlying = typename std::underlying_type<PeakInterpolationType>::type;


### PR DESCRIPTION
This is necessitated by "ENH: Declare converting Point(v) constructors explicit" from Feb 28th:
https://github.com/InsightSoftwareConsortium/ITK/commit/8825834406356a66705437b74c843a54a47c57c3

The first [error message](https://open.cdash.org/viewBuildError.php?buildid=7779138) was:
```
1>m:\dashboard\itk\modules\remote\montage\include\itkPhaseCorrelationImageRegistrationMethod.hxx(251): error C2440: 'initializing': cannot convert from 'itk::Vector<double,2>' to 'itk::Point<double,2>'
1>m:\dashboard\itk\modules\remote\montage\include\itkPhaseCorrelationImageRegistrationMethod.hxx(251): note: Constructor for class 'itk::Point<double,2>' is declared 'explicit'
```