### PR TITLE
COMP: Fix discarding return value warning introduced by ITK 5.4

### DIFF
--- a/include/itkTileMergeImageFilter.hxx
+++ b/include/itkTileMergeImageFilter.hxx
@@ -314,15 +314,16 @@ TileMergeImageFilter<TImageType, TPixelAccumulateType, TInterpolator>::GenerateO
     PointType         iOrigin = input->GetOrigin();
     iOrigin = inverseT->TransformPoint(iOrigin);
 
-    ContinuousIndexType ci;
-    outputImage->TransformPhysicalPointToContinuousIndex(iOrigin, ci);
+    const ContinuousIndexType ci =
+      outputImage->template TransformPhysicalPointToContinuousIndex<typename TInterpolator::CoordRepType,
+                                                                    typename PointType::ValueType>(iOrigin);
     for (unsigned d = 0; d < ImageDimension; d++)
     {
       m_InputsContinuousIndices[i][d] = ci[d] + input->GetLargestPossibleRegion().GetIndex(d);
     }
 
-    ImageIndexType ind;
-    outputImage->TransformPhysicalPointToIndex(iOrigin, ind);
+    const ImageIndexType ind =
+      outputImage->template TransformPhysicalPointToIndex<typename PointType::ValueType>(iOrigin);
     RegionType reg = input->GetLargestPossibleRegion();
     for (unsigned d = 0; d < ImageDimension; d++)
     {

--- a/include/itkTileMontage.hxx
+++ b/include/itkTileMontage.hxx
@@ -353,7 +353,7 @@ TileMontage<TImageType, TCoordinate>::UpdateMosaicBounds(TileIndexType         i
   TransformPointer inverseT = TransformType::New();
   transform->GetInverse(inverseT);
   p = inverseT->TransformPoint(p);
-  input0->TransformPhysicalPointToContinuousIndex(p, ci);
+  ci = input0->template TransformPhysicalPointToContinuousIndex<TCoordinate, typename PointType::ValueType>(p);
   for (unsigned d = 0; d < ImageDimension; d++)
   {
     if (index[d] == 0) // this tile is on the minimum edge
@@ -365,7 +365,7 @@ TileMontage<TImageType, TCoordinate>::UpdateMosaicBounds(TileIndexType         i
   ind += input->GetLargestPossibleRegion().GetSize();
   input->TransformIndexToPhysicalPoint(ind, p);
   p = inverseT->TransformPoint(p);
-  input0->TransformPhysicalPointToContinuousIndex(p, ci);
+  ci = input0->template TransformPhysicalPointToContinuousIndex<TCoordinate, typename PointType::ValueType>(p);
   for (unsigned d = 0; d < ImageDimension; d++)
   {
     if (index[d] == m_MontageSize[d] - 1) // this tile is on the maximum edge


### PR DESCRIPTION
M:\Dashboard\ITK\Modules\Remote\Montage\include\itkTileMergeImageFilter.hxx(318,57): warning C4834: discarding return value of function with 'nodiscard' attribute [M:\Dashboard\ITK-build\Modules\Remote\Montage\test\MontageTestDriver.vcxproj]