### PR TITLE
Avoid appearance of NaN values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 
 if(CMAKE_CXX_STANDARD EQUAL "98" )
    message(FATAL_ERROR "CMAKE_CXX_STANDARD:STRING=98 is not supported in ITK version 5 and greater.")
 endif()
 
 if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14) # Supported values are ``11``, ``14``, and ``17``.
+  set(CMAKE_CXX_STANDARD 17) # Supported values are ``17``, ``20``, and ``23``.
 endif()
 if(NOT CMAKE_CXX_STANDARD_REQUIRED)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 project(ITKMontageExamples)
 
 set(ExampleSpecificComponents

--- a/include/itkPhaseCorrelationImageRegistrationMethod.hxx
+++ b/include/itkPhaseCorrelationImageRegistrationMethod.hxx
@@ -207,8 +207,9 @@ PhaseCorrelationImageRegistrationMethod<TFixedImage, TMovingImage, TInternalPixe
 
 
 template <typename TFixedImage, typename TMovingImage, typename TInternalPixelType>
-typename PhaseCorrelationImageRegistrationMethod<TFixedImage, TMovingImage, TInternalPixelType>::SizeType
+auto
 PhaseCorrelationImageRegistrationMethod<TFixedImage, TMovingImage, TInternalPixelType>::RoundUpToFFTSize(SizeType size)
+  -> SizeType
 {
   // FFTs are faster when image size can be factorized using smaller prime numbers
   const auto sizeGreatestPrimeFactor = std::min<SizeValueType>(5, m_FixedFFT->GetSizeGreatestPrimeFactor());

--- a/include/itkTileMontage.hxx
+++ b/include/itkTileMontage.hxx
@@ -30,6 +30,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cmath>
 #include <iomanip>
 
 namespace itk
@@ -280,11 +281,24 @@ TileMontage<TImageType, TCoordinate>::RegisterPair(TileIndexType fixed, TileInde
 
   m_CandidateConfidences[regLinearIndex] = m_PCM->GetConfidences();
   m_TransformCandidates[regLinearIndex].resize(offsets.size());
-  PointType p0;
-  p0.Fill(0.0);
   for (unsigned i = 0; i < offsets.size(); i++)
   {
-    m_TransformCandidates[regLinearIndex][i] = offsets[i] - p0;
+    if (m_CandidateConfidences[regLinearIndex][i] == 0)
+    {
+      m_CandidateConfidences[regLinearIndex][i] = std::numeric_limits<TCoordinate>::epsilon();
+    }
+
+    for (unsigned d = 0; d < ImageDimension; d++)
+    {
+      if (std::isfinite(offsets[i][d]))
+      {
+        m_TransformCandidates[regLinearIndex][i][d] = offsets[i][d];
+      }
+      else
+      {
+        m_TransformCandidates[regLinearIndex][i][d] = 0;
+      }
+    }
   }
 }
 

--- a/include/itkTileMontage.hxx
+++ b/include/itkTileMontage.hxx
@@ -582,6 +582,7 @@ TileMontage<TImageType, TCoordinate>::OptimizeTiles()
       {
         std::cout << m_TransformCandidates[candidateIndex][0];
         m_TransformCandidates[candidateIndex].erase(m_TransformCandidates[candidateIndex].begin());
+        m_CandidateConfidences[candidateIndex].erase(m_CandidateConfidences[candidateIndex].begin());
       }
       else
       {

--- a/include/itkTileMontage.hxx
+++ b/include/itkTileMontage.hxx
@@ -176,8 +176,8 @@ TileMontage<TImageType, TCoordinate>::GetImageHelper(TileIndexType nDIndex, bool
 }
 
 template <typename TImageType, typename TCoordinate>
-typename TileMontage<TImageType, TCoordinate>::ImageType::Pointer
-TileMontage<TImageType, TCoordinate>::GetImage(TileIndexType nDIndex, bool metadataOnly)
+auto
+TileMontage<TImageType, TCoordinate>::GetImage(TileIndexType nDIndex, bool metadataOnly) -> typename ImageType::Pointer
 {
   RegionType                  reg0; // default-initialized to zeroes
   SizeValueType               linearIndex = this->nDIndexToLinearIndex(nDIndex);
@@ -213,8 +213,9 @@ TileMontage<TImageType, TCoordinate>::nDIndexToLinearIndex(TileIndexType nDIndex
 }
 
 template <typename TImageType, typename TCoordinate>
-typename TileMontage<TImageType, TCoordinate>::TileIndexType
+auto
 TileMontage<TImageType, TCoordinate>::LinearIndexTonDIndex(DataObject::DataObjectPointerArraySizeType linearIndex) const
+  -> TileIndexType
 {
   TileIndexType ind;
   SizeValueType stride = 1u;


### PR DESCRIPTION
This can be caused by 0 confidence values, probably due to large homogeneous (all black) regions.

Closes #219.