### PR TITLE
COMP: Fix HyperSphereImageSource class name in type macro (was Image)

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,12 +4,12 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@f2191a014a93c0d0e7b9e7ffb32d2e1118fb2876
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@246883ef3828fc00219145aeec9efa67b9889d0b
     with:
       cmake-options: "Module_Montage_BUILD_EXAMPLES:BOOL=ON"
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@f2191a014a93c0d0e7b9e7ffb32d2e1118fb2876
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@246883ef3828fc00219145aeec9efa67b9889d0b
     with:
       manylinux-platforms: '["_2_28-x64","2014-x64"]'
       test-notebooks: true

--- a/test/itkMontagePCMTestSynthetic.cxx
+++ b/test/itkMontagePCMTestSynthetic.cxx
@@ -39,7 +39,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(Image, Object);
+  itkTypeMacro(HyperSphereImageSource, Object);
 
   using ImageType = itk::Image<TPixel, VDimension>;
 


### PR DESCRIPTION
Problem reported here: https://github.com/InsightSoftwareConsortium/ITK/pull/4378#issuecomment-1877085840