### PR TITLE
ENH: Upgrade CI for ITK 5.4.0

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -1,16 +1,15 @@
 name: Build, test, package
-
-on: [push,pull_request]
-
+true:
+- push
+- pull_request
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@b223658f3ab10680ab2ec3286d070b9601ea6ef1
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
     with:
-      cmake-options: "Module_Montage_BUILD_EXAMPLES:BOOL=ON"
-
+      cmake-options: Module_Montage_BUILD_EXAMPLES:BOOL=ON
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@b223658f3ab10680ab2ec3286d070b9601ea6ef1
-    with:
-      test-notebooks: true
     secrets:
       pypi_password: ${{ secrets.pypi_password }}
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
+    with:
+      test-notebooks: true


### PR DESCRIPTION
Upgrade CI testing to use the latest ITK 5.4.0 version and CI configuration.

Committed via https://github.com/asottile/all-repos