### PR TITLE
COMP: Replace `CoordRepType` with `CoordinateType`

### DIFF
--- a/include/itkTileMergeImageFilter.h
+++ b/include/itkTileMergeImageFilter.h
@@ -49,7 +49,7 @@ template <typename TImageType,
 class ITK_TEMPLATE_EXPORT TileMergeImageFilter
   : public TileMontage<
       Image<typename NumericTraits<typename TImageType::PixelType>::ValueType, TImageType::ImageDimension>,
-      typename TInterpolator::CoordRepType>
+      typename TInterpolator::CoordinateType>
 {
 public:
   ITK_DISALLOW_COPY_AND_MOVE(TileMergeImageFilter);
@@ -57,7 +57,7 @@ public:
   /** We define superclass with scalar pixel type, to enable compiling even when RGB pixel is supplied. */
   using Superclass =
     TileMontage<Image<typename NumericTraits<typename TImageType::PixelType>::ValueType, TImageType::ImageDimension>,
-                typename TInterpolator::CoordRepType>;
+                typename TInterpolator::CoordinateType>;
 
   /** Standard class type aliases. */
   using Self = TileMergeImageFilter;

--- a/include/itkTileMergeImageFilter.hxx
+++ b/include/itkTileMergeImageFilter.hxx
@@ -265,10 +265,10 @@ TileMergeImageFilter<TImageType, TPixelAccumulateType, TInterpolator>::GenerateO
   if (m_Montage.IsNull())
   {
     // initialize mosaic bounds
-    this->m_MinInner.Fill(NumericTraits<typename TInterpolator::CoordRepType>::NonpositiveMin());
-    this->m_MinOuter.Fill(NumericTraits<typename TInterpolator::CoordRepType>::max());
-    this->m_MaxOuter.Fill(NumericTraits<typename TInterpolator::CoordRepType>::NonpositiveMin());
-    this->m_MaxInner.Fill(NumericTraits<typename TInterpolator::CoordRepType>::max());
+    this->m_MinInner.Fill(NumericTraits<typename TInterpolator::CoordinateType>::NonpositiveMin());
+    this->m_MinOuter.Fill(NumericTraits<typename TInterpolator::CoordinateType>::max());
+    this->m_MaxOuter.Fill(NumericTraits<typename TInterpolator::CoordinateType>::NonpositiveMin());
+    this->m_MaxInner.Fill(NumericTraits<typename TInterpolator::CoordinateType>::max());
 
     for (SizeValueType i = 0; i < this->m_LinearMontageSize; i++)
     {
@@ -315,7 +315,7 @@ TileMergeImageFilter<TImageType, TPixelAccumulateType, TInterpolator>::GenerateO
     iOrigin = inverseT->TransformPoint(iOrigin);
 
     const ContinuousIndexType ci =
-      outputImage->template TransformPhysicalPointToContinuousIndex<typename TInterpolator::CoordRepType,
+      outputImage->template TransformPhysicalPointToContinuousIndex<typename TInterpolator::CoordinateType,
                                                                     typename PointType::ValueType>(iOrigin);
     for (unsigned d = 0; d < ImageDimension; d++)
     {


### PR DESCRIPTION
Addressed the warnings at https://open.cdash.org/viewBuildError.php?type=1&buildid=10063093 reported by Dženan Zukić (@dzenanz) at https://github.com/InsightSoftwareConsortium/ITK/pull/5006#issuecomment-2515093995

Following ITK pull request https://github.com/InsightSoftwareConsortium/ITK/pull/4997 commit https://github.com/InsightSoftwareConsortium/ITK/commit/e667fa39a6914d666ae5dd0b47202ebfb2acfd1f