### PR TITLE
COMP: Update CI best practices and Python 3.10+

### DIFF
--- a/.github/workflows/apply-clang-format.yml
+++ b/.github/workflows/apply-clang-format.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: InsightSoftwareConsortium/ITKApplyClangFormatAction@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,12 +4,12 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.5
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
     with:
       cmake-options: "Module_Montage_BUILD_EXAMPLES:BOOL=ON"
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     with:
       test-notebooks: true
     secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Build artifacts
+dist/
+build/
+*.egg-info/
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "itk-core>=5.4.2",
     "itk-filtering>=5.4.2",


### PR DESCRIPTION
Update CI workflows to current best practices: actions/checkout@v5, Python 3.10+ minimum, and ITKRemoteModuleBuildTestPackageAction@v5.4.6 with ITK wheel tags pinned to v5.4.5.

Note: Windows Python wheels may fail with `ensurepip` until ITKPythonPackage cuts a new release tag including the fix. C++ CI and Linux/macOS Python builds are unaffected.

<details>
<summary>Commits (3)</summary>

1. **COMP: Update actions/checkout to v5**
2. **COMP: Update minimum Python version to 3.10+** — bump pyproject.toml and workflow matrix
3. **COMP: Update action to v5.4.6 and ITK wheel tags to v5.4.5**

</details>

<details>
<summary>Dropped commit</summary>

`48fe55c` ("COMP: Point itk-python-package-tag at main for Windows pip fix") was dropped — using `itk-python-package-tag: 'main'` fixed the Windows ensurepip issue but broke Linux Python wrapping due to CastXML incompatibility with gcc-toolset-14 in the latest manylinux container.

</details>

<!--
provenance: claude-code session 2026-04-15
dropped: 48fe55c (itk-python-package-tag: main — CastXML/gcc14 incompatibility on Linux)
known_issue: Windows Python wheels may fail until ITKPythonPackage tags a new release
-->